### PR TITLE
Update ring-proof rev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rand_chacha = { version = "0.3", default-features = false }
 rayon = { version = "1.10", default-features = false, optional = true }
 hmac = {version = "0.12", default-features = false, optional = true }
 # Waiting for crates.io
-ring-proof = { package = "ring", git = "https://github.com/davxy/ring-proof", rev = "d3e37f9", default-features = false, optional = true }
+ring-proof = { package = "ring", git = "https://github.com/davxy/ring-proof", rev = "db13482", default-features = false, optional = true }
 # Curves
 ark-secp256r1 = { version = "0.4.0", default-features = false, optional = true }
 ark-ed25519 = { version = "0.4.0", default-features = false, optional = true }

--- a/src/utils/elligator2.rs
+++ b/src/utils/elligator2.rs
@@ -166,6 +166,8 @@ impl<P: Elligator2Config> MapToCurve<Projective<P>> for Elligator2Map<P> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(non_local_definitions)]
+
     use super::*;
     use ark_ec::hashing::{map_to_curve_hasher::MapToCurveBasedHasher, HashToCurve};
     use ark_ff::{field_hashers::DefaultFieldHasher, Fp64, MontBackend, MontFp};


### PR DESCRIPTION
This ring-proof revision is anchored to fflonk:
- Ring proof rev: https://github.com/davxy/ring-proof/tree/db1348254177325ef849ed87fb87e5ec9184080f
- Fflonk rev: https://github.com/davxy/fflonk/tree/1e854f35e9a65d08b11a86291405cdc95baa0a35