### PR TITLE
Pedersen: Add verify_with_rng to BatchVerifier

### DIFF
--- a/benches/pedersen.rs
+++ b/benches/pedersen.rs
@@ -1,10 +1,10 @@
 #[macro_use]
 mod bench_utils;
 
-use ark_std::{rand::SeedableRng, UniformRand};
-use ark_vrf::{pedersen::PedersenSuite, AffinePoint, Input, Public, Secret};
+use ark_std::{UniformRand, rand::SeedableRng};
+use ark_vrf::{AffinePoint, Input, Public, Secret, pedersen::PedersenSuite};
 use bench_utils::BenchInfo;
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 
 fn bench_pedersen_prove<S: BenchInfo + PedersenSuite>(c: &mut Criterion) {
     use ark_vrf::pedersen::Prover;

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -433,7 +433,7 @@ impl<S: PedersenSuite> BatchVerifier<S> {
 #[cfg(test)]
 pub(crate) mod testing {
     use super::*;
-    use crate::testing::{self as common, random_val, CheckPoint, SuiteExt, TEST_SEED};
+    use crate::testing::{self as common, CheckPoint, SuiteExt, TEST_SEED, random_val};
 
     pub fn prove_verify<S: PedersenSuite>() {
         use pedersen::{Prover, Verifier};


### PR DESCRIPTION
- Add `verify_with_rng` method to Pedersen `BatchVerifier` accepting a generic  `R: RngCore + CryptoRng` for random scalar generation during batch verification.
- The existing `verify()` method now builds a deterministic ChaCha20Rng from proof data and delegates to `verify_with_rng`.
- Add benchmark for the `verify_with_rng` path.

