### PR TITLE
Multi i/o VRF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - Unreleased
 
 ### Added
 
-- Multi-input IETF VRF (`prove_multi`/`verify_multi`) using delinearized DLEQ.
-  Proves multiple input-output pairs with a single proof. N=1 is byte-identical
+- Multi-input IETF VRF using delinearized DLEQ. Proves multiple input-output
+  pairs with a single proof via `delinearize` folding. N=1 is byte-identical
   to standard RFC-9381. N=0 reduces to a Schnorr signature over additional data.
-
-## [0.3.0] - 2026-02-25
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Multi-input IETF VRF (`prove_multi`/`verify_multi`) using delinearized DLEQ.
+  Proves multiple input-output pairs with a single proof. N=1 is byte-identical
+  to standard RFC-9381. N=0 reduces to a Schnorr signature over additional data.
+
 ## [0.3.0] - 2026-02-25
 
 ### Fixed

--- a/benches/SUMMARY.md
+++ b/benches/SUMMARY.md
@@ -28,6 +28,15 @@ Criterion: `--quick` mode
 | scalar_encode                | 21.2 ns  |
 | scalar_decode                | 120.9 ns |
 
+### Delinearization
+
+| Benchmark      | n=2     | n=4     | n=8     | n=16    | n=32    | n=64    | n=128   | n=256   |
+|:---------------|---------|---------|---------|---------|---------|---------|---------|---------|
+| delinearize    | 177 us  | 401 us  | 805 us  | 1.15 ms | 2.13 ms | 3.49 ms | 4.45 ms | 7.51 ms |
+
+Uses a hybrid strategy: sequential fold for N < 16, MSM (Pippenger) for N >= 16.
+Small N avoids MSM's bucket-setup overhead; large N benefits from sublinear scaling.
+
 ## IETF VRF Operations (`ietf.rs`)
 
 | Benchmark              |     Time |

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -144,12 +144,7 @@ fn bench_delinearize<S: BenchInfo>(c: &mut Criterion) {
     for &size in DELINEARIZE_SIZES {
         c.benchmark_group(&group_name)
             .bench_function(BenchmarkId::from_parameter(size), |b| {
-                b.iter(|| {
-                    ark_vrf::utils::delinearize::<S>(
-                        black_box(&ios[..size]),
-                        b"ad",
-                    )
-                });
+                b.iter(|| ark_vrf::utils::delinearize::<S>(black_box(&ios[..size]), b"ad"));
             });
     }
 }

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -146,7 +146,6 @@ fn bench_delinearize<S: BenchInfo>(c: &mut Criterion) {
             .bench_function(BenchmarkId::from_parameter(size), |b| {
                 b.iter(|| {
                     ark_vrf::utils::delinearize::<S>(
-                        black_box(0x04),
                         black_box(&ios[..size]),
                         b"ad",
                     )

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -1,10 +1,10 @@
 #[macro_use]
 mod bench_utils;
 
-use ark_std::{rand::SeedableRng, UniformRand};
+use ark_std::{UniformRand, rand::SeedableRng};
 use ark_vrf::{AffinePoint, Input, Output, Secret};
 use bench_utils::BenchInfo;
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 
 fn bench_key_from_seed<S: BenchInfo>(c: &mut Criterion) {
     let name = format!("{}/key_from_seed", S::SUITE_NAME);

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -1,10 +1,10 @@
 #[macro_use]
 mod bench_utils;
 
-use ark_std::{UniformRand, rand::SeedableRng};
-use ark_vrf::{AffinePoint, Input, Secret};
+use ark_std::{rand::SeedableRng, UniformRand};
+use ark_vrf::{AffinePoint, Input, Output, Secret};
 use bench_utils::BenchInfo;
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
 fn bench_key_from_seed<S: BenchInfo>(c: &mut Criterion) {
     let name = format!("{}/key_from_seed", S::SUITE_NAME);
@@ -126,6 +126,35 @@ fn bench_scalar_decode<S: BenchInfo>(c: &mut Criterion) {
     });
 }
 
+fn bench_delinearize<S: BenchInfo>(c: &mut Criterion) {
+    const DELINEARIZE_SIZES: &[usize] = &[2, 4, 8, 16, 32, 64, 128, 256];
+    let secret = Secret::<S>::from_seed(b"bench secret seed");
+    let max_size = DELINEARIZE_SIZES[DELINEARIZE_SIZES.len() - 1];
+
+    let mut rng = rand_chacha::ChaCha20Rng::from_seed([42; 32]);
+    let ios: Vec<(Input<S>, Output<S>)> = (0..max_size)
+        .map(|_| {
+            let input = Input::<S>::from_affine(AffinePoint::<S>::rand(&mut rng));
+            let output = secret.output(input);
+            (input, output)
+        })
+        .collect();
+
+    let group_name = format!("{}/delinearize", S::SUITE_NAME);
+    for &size in DELINEARIZE_SIZES {
+        c.benchmark_group(&group_name)
+            .bench_function(BenchmarkId::from_parameter(size), |b| {
+                b.iter(|| {
+                    ark_vrf::utils::delinearize::<S>(
+                        black_box(0x04),
+                        black_box(&ios[..size]),
+                        b"ad",
+                    )
+                });
+            });
+    }
+}
+
 // All common benchmarks for a single suite.
 fn bench_common_suite<S: BenchInfo>(c: &mut Criterion) {
     S::print_info();
@@ -140,6 +169,7 @@ fn bench_common_suite<S: BenchInfo>(c: &mut Criterion) {
     bench_point_decode::<S>(c);
     bench_scalar_encode::<S>(c);
     bench_scalar_decode::<S>(c);
+    bench_delinearize::<S>(c);
 }
 
 fn bench_common(c: &mut Criterion) {

--- a/src/ietf.rs
+++ b/src/ietf.rs
@@ -104,40 +104,11 @@ impl<S: IetfSuite> ark_serialize::Valid for Proof<S> {
     }
 }
 
-/// Delinearize and merge multiple input-output pairs into a single pair.
-///
-/// - N=0: returns the identity point for both input and output.
-/// - N=1: returns the pair as-is, no delinearization.
-/// - N>1: derives 128-bit delinearization scalars and returns
-///   `(sum(z_i * H_i), sum(z_i * Gamma_i))`.
-fn merge<S: IetfSuite>(
-    pk: &Public<S>,
-    ios: &[(Input<S>, Output<S>)],
-    ad: &[u8],
-) -> (Input<S>, Output<S>) {
-    if ios.len() == 1 {
-        return (ios[0].0, ios[0].1);
-    }
-
-    let zs = utils::delinearization_scalars::<S>(&pk.0, ios, ad);
-
-    type Projective<S> = <AffinePoint<S> as AffineRepr>::Group;
-    let (input, output) = ios.iter().zip(zs.iter()).fold(
-        (Projective::<S>::zero(), Projective::<S>::zero()),
-        |(h_acc, g_acc), ((i, o), z)| (h_acc + i.0 * z, g_acc + o.0 * z),
-    );
-    let norms = CurveGroup::normalize_batch(&[input, output]);
-    (Input(norms[0]), Output(norms[1]))
-}
-
 /// Trait for types that can generate VRF proofs.
 ///
 /// Implementors can create cryptographic proofs that a VRF output
 /// is correctly derived from an input using their secret key.
 pub trait Prover<S: IetfSuite> {
-    /// The public key associated with this prover.
-    fn public_key(&self) -> Public<S>;
-
     /// Generate a proof for the given input/output and additional data.
     ///
     /// Creates a non-interactive zero-knowledge proof binding the input, output,
@@ -147,19 +118,6 @@ pub trait Prover<S: IetfSuite> {
     /// * `output` - VRF output point (γ = x·H)
     /// * `ad` - Additional data to bind to the proof
     fn prove(&self, input: Input<S>, output: Output<S>, ad: impl AsRef<[u8]>) -> Proof<S>;
-
-    /// Generate a proof for multiple input-output pairs using delinearized DLEQ.
-    ///
-    /// When `ios` has a single element, the proof is byte-identical to [`Prover::prove`].
-    /// For N>1, delinearization scalars merge all input-output pairs into a single
-    /// DLEQ proof, amortizing proof size.
-    ///
-    /// When `ios` is empty, the merged input and output are both the identity point,
-    /// reducing to a Schnorr signature over the additional data.
-    fn prove_multi(&self, ios: &[(Input<S>, Output<S>)], ad: impl AsRef<[u8]>) -> Proof<S> {
-        let (input, output) = merge(&self.public_key(), ios, ad.as_ref());
-        self.prove(input, output, ad)
-    }
 }
 
 /// Trait for entities that can verify VRF proofs.
@@ -167,9 +125,6 @@ pub trait Prover<S: IetfSuite> {
 /// Implementors can verify that a VRF output is correctly derived
 /// from an input using a specific public key.
 pub trait Verifier<S: IetfSuite> {
-    /// The public key associated with this verifier.
-    fn public_key(&self) -> Public<S>;
-
     /// Verify a proof for the given input/output and additional data.
     ///
     /// Verifies the cryptographic relationship between input, output, and proof
@@ -188,30 +143,9 @@ pub trait Verifier<S: IetfSuite> {
         aux: impl AsRef<[u8]>,
         proof: &Proof<S>,
     ) -> Result<(), Error>;
-
-    /// Verify a proof for multiple input-output pairs using delinearized DLEQ.
-    ///
-    /// When `ios` has a single element, delegates to [`Verifier::verify`].
-    /// For N>1, recomputes delinearization scalars and verifies the merged DLEQ.
-    ///
-    /// When `ios` is empty, the merged input and output are both the identity point,
-    /// reducing to a Schnorr signature verification over the additional data.
-    fn verify_multi(
-        &self,
-        ios: &[(Input<S>, Output<S>)],
-        ad: impl AsRef<[u8]>,
-        proof: &Proof<S>,
-    ) -> Result<(), Error> {
-        let (input, output) = merge(&self.public_key(), ios, ad.as_ref());
-        self.verify(input, output, ad, proof)
-    }
 }
 
 impl<S: IetfSuite> Prover<S> for Secret<S> {
-    fn public_key(&self) -> Public<S> {
-        self.public
-    }
-
     /// Implements the IETF VRF proving algorithm.
     ///
     /// This follows the procedure specified in RFC-9381 section 5.1, with extensions
@@ -240,10 +174,6 @@ impl<S: IetfSuite> Prover<S> for Secret<S> {
 }
 
 impl<S: IetfSuite> Verifier<S> for Public<S> {
-    fn public_key(&self) -> Public<S> {
-        *self
-    }
-
     /// Implements the IETF VRF verification algorithm.
     ///
     /// This follows the procedure specified in RFC-9381 section 5.3, with extensions
@@ -280,9 +210,11 @@ pub mod testing {
     use super::*;
     use crate::testing::{self as common, SuiteExt};
 
-    pub fn prove_verify<S: IetfSuite>() {
-        use ietf::{Prover, Verifier};
+    fn merge<S: IetfSuite>(ios: &[(Input<S>, Output<S>)], ad: &[u8]) -> (Input<S>, Output<S>) {
+        utils::merge::<S>(123, ios, ad)
+    }
 
+    pub fn prove_verify<S: IetfSuite>() {
         let secret = Secret::<S>::from_seed(common::TEST_SEED);
         let public = secret.public();
         let input = Input::from_affine(common::random_val(None));
@@ -293,11 +225,24 @@ pub mod testing {
         assert!(result.is_ok());
     }
 
-    /// N=1 multi proof must be byte-identical to standard Prover::prove,
+    pub fn prove_verify_multi_empty<S: IetfSuite>() {
+        let secret = Secret::<S>::from_seed(common::TEST_SEED);
+        let public = secret.public();
+
+        let (input, output) = merge(&[], b"bar");
+        assert_eq!(input.0, output.0);
+        assert_eq!(input.0, S::Affine::zero());
+        let proof = secret.prove(input, output, b"bar");
+
+        assert!(public.verify(input, output, b"bar", &proof).is_ok());
+
+        let (bi, bo) = merge(&[], b"baz");
+        assert!(public.verify(bi, bo, b"baz", &proof).is_err());
+    }
+
+    /// N=1 merge + prove must be byte-identical to standard Prover::prove,
     /// and cross-verification works in both directions.
     pub fn prove_verify_multi_single<S: IetfSuite>() {
-        use ietf::{Prover, Verifier};
-
         let secret = Secret::<S>::from_seed(common::TEST_SEED);
         let public = secret.public();
         let input = Input::from_affine(common::random_val(None));
@@ -305,7 +250,8 @@ pub mod testing {
 
         let proof_std = secret.prove(input, output, b"foo");
         let io = (input, output);
-        let proof_multi = secret.prove_multi(&[io], b"foo");
+        let (mi, mo) = merge(&[io], b"foo");
+        let proof_multi = secret.prove(mi, mo, b"foo");
 
         // Byte-identical proofs
         let encode = |p: &ietf::Proof<S>| {
@@ -315,10 +261,9 @@ pub mod testing {
         };
         assert_eq!(encode(&proof_std), encode(&proof_multi));
 
-        // Cross-verification: multi proof verifies via standard verifier
+        // Cross-verification
         assert!(public.verify(input, output, b"foo", &proof_multi).is_ok());
-        // Standard proof verifies via multi verifier
-        assert!(public.verify_multi(&[io], b"foo", &proof_std).is_ok());
+        assert!(public.verify(mi, mo, b"foo", &proof_std).is_ok());
     }
 
     /// N=3 multi proof: verify succeeds; tampered output/input/ad fails.
@@ -326,37 +271,33 @@ pub mod testing {
         let secret = Secret::<S>::from_seed(common::TEST_SEED);
         let public = secret.public();
 
-        let ios: Vec<(Input<S>, Output<S>)> = (0..3u8)
+        let mut ios: Vec<(Input<S>, Output<S>)> = (0..3u8)
             .map(|i| {
                 let input = Input::new(&[i + 1]).unwrap();
                 (input, secret.output(input))
             })
             .collect();
+        ios.push((Input(S::Affine::generator()), Output(public.0)));
 
-        let proof = secret.prove_multi(&ios, b"bar");
-        assert!(public.verify_multi(&ios, b"bar", &proof).is_ok());
+        let (input, output) = merge(&ios, b"bar");
+        let proof = secret.prove(input, output, b"bar");
+        assert!(public.verify(input, output, b"bar", &proof).is_ok());
 
         // Tamper: wrong output on ios[1]
         let mut bad_ios = ios.clone();
-        bad_ios[1].1 = secret.output(ios[0].0); // wrong output for that input
-        assert!(public.verify_multi(&bad_ios, b"bar", &proof).is_err());
+        bad_ios[1].1 = secret.output(ios[0].0);
+        let (bi, bo) = merge(&bad_ios, b"bar");
+        assert!(public.verify(bi, bo, b"bar", &proof).is_err());
 
         // Tamper: wrong input on ios[0]
         let mut bad_ios = ios.clone();
         bad_ios[0].0 = ios[1].0;
-        assert!(public.verify_multi(&bad_ios, b"bar", &proof).is_err());
+        let (bi, bo) = merge(&bad_ios, b"bar");
+        assert!(public.verify(bi, bo, b"bar", &proof).is_err());
 
         // Tamper: wrong ad
-        assert!(public.verify_multi(&ios, b"baz", &proof).is_err());
-    }
-
-    pub fn prove_verify_multi_empty<S: IetfSuite>() {
-        let secret = Secret::<S>::from_seed(common::TEST_SEED);
-        let public = secret.public();
-        let proof = secret.prove_multi(&[], b"bar");
-
-        assert!(public.verify_multi(&[], b"bar", &proof).is_ok());
-        assert!(public.verify_multi(&[], b"baz", &proof).is_err());
+        let (bi, bo) = merge(&ios, b"baz");
+        assert!(public.verify(bi, bo, b"baz", &proof).is_err());
     }
 
     #[macro_export]

--- a/src/ietf.rs
+++ b/src/ietf.rs
@@ -211,7 +211,7 @@ pub mod testing {
     use crate::testing::{self as common, SuiteExt};
 
     fn merge<S: IetfSuite>(ios: &[(Input<S>, Output<S>)], ad: &[u8]) -> (Input<S>, Output<S>) {
-        utils::delinearize::<S>(123, ios, ad)
+        utils::delinearize::<S>(ios, ad)
     }
 
     pub fn prove_verify<S: IetfSuite>() {

--- a/src/ietf.rs
+++ b/src/ietf.rs
@@ -205,6 +205,66 @@ impl<S: IetfSuite> Verifier<S> for Public<S> {
     }
 }
 
+/// Delinearize and merge multiple input-output pairs into a single pair.
+///
+/// - N=0: returns the identity point for both input and output.
+/// - N=1: returns the pair as-is, no delinearization.
+/// - N>1: derives 128-bit delinearization scalars and returns
+///   `(sum(z_i * H_i), sum(z_i * Gamma_i))`.
+fn merge<S: IetfSuite>(
+    pk: &Public<S>,
+    ios: &[(Input<S>, Output<S>)],
+    ad: &[u8],
+) -> (Input<S>, Output<S>) {
+    if ios.len() == 1 {
+        return (ios[0].0, ios[0].1);
+    }
+
+    let zs = utils::delinearization_scalars::<S>(&pk.0, ios, ad);
+
+    type Projective<S> = <AffinePoint<S> as AffineRepr>::Group;
+    let (input, output) = ios.iter().zip(zs.iter()).fold(
+        (Projective::<S>::zero(), Projective::<S>::zero()),
+        |(h_acc, g_acc), ((i, o), z)| (h_acc + i.0 * z, g_acc + o.0 * z),
+    );
+    let norms = CurveGroup::normalize_batch(&[input, output]);
+    (Input(norms[0]), Output(norms[1]))
+}
+
+impl<S: IetfSuite> Secret<S> {
+    /// Generate a proof for multiple input-output pairs using delinearized DLEQ.
+    ///
+    /// When `ios` has a single element, the proof is byte-identical to [`Prover::prove`].
+    /// For N>1, delinearization scalars merge all input-output pairs into a single
+    /// DLEQ proof, amortizing proof size.
+    ///
+    /// When `ios` is empty, the merged input and output are both the identity point,
+    /// reducing to a Schnorr signature over the additional data.
+    pub fn prove_multi(&self, ios: &[(Input<S>, Output<S>)], ad: impl AsRef<[u8]>) -> Proof<S> {
+        let (input, output) = merge(&self.public, ios, ad.as_ref());
+        Prover::prove(self, input, output, ad)
+    }
+}
+
+impl<S: IetfSuite> Public<S> {
+    /// Verify a proof for multiple input-output pairs using delinearized DLEQ.
+    ///
+    /// When `ios` has a single element, delegates to [`Verifier::verify`].
+    /// For N>1, recomputes delinearization scalars and verifies the merged DLEQ.
+    ///
+    /// When `ios` is empty, the merged input and output are both the identity point,
+    /// reducing to a Schnorr signature verification over the additional data.
+    pub fn verify_multi(
+        &self,
+        ios: &[(Input<S>, Output<S>)],
+        ad: impl AsRef<[u8]>,
+        proof: &Proof<S>,
+    ) -> Result<(), Error> {
+        let (input, output) = merge(self, ios, ad.as_ref());
+        Verifier::verify(self, input, output, ad, proof)
+    }
+}
+
 #[cfg(test)]
 pub mod testing {
     use super::*;
@@ -223,6 +283,72 @@ pub mod testing {
         assert!(result.is_ok());
     }
 
+    /// N=1 multi proof must be byte-identical to standard Prover::prove,
+    /// and cross-verification works in both directions.
+    pub fn prove_verify_multi_single<S: IetfSuite>() {
+        use ietf::{Prover, Verifier};
+
+        let secret = Secret::<S>::from_seed(common::TEST_SEED);
+        let public = secret.public();
+        let input = Input::from_affine(common::random_val(None));
+        let output = secret.output(input);
+
+        let proof_std = secret.prove(input, output, b"foo");
+        let io = (input, output);
+        let proof_multi = secret.prove_multi(&[io], b"foo");
+
+        // Byte-identical proofs
+        let encode = |p: &ietf::Proof<S>| {
+            let mut buf = Vec::new();
+            p.serialize_compressed(&mut buf).unwrap();
+            buf
+        };
+        assert_eq!(encode(&proof_std), encode(&proof_multi));
+
+        // Cross-verification: multi proof verifies via standard verifier
+        assert!(public.verify(input, output, b"foo", &proof_multi).is_ok());
+        // Standard proof verifies via multi verifier
+        assert!(public.verify_multi(&[io], b"foo", &proof_std).is_ok());
+    }
+
+    /// N=3 multi proof: verify succeeds; tampered output/input/ad fails.
+    pub fn prove_verify_multi<S: IetfSuite>() {
+        let secret = Secret::<S>::from_seed(common::TEST_SEED);
+        let public = secret.public();
+
+        let ios: Vec<(Input<S>, Output<S>)> = (0..3u8)
+            .map(|i| {
+                let input = Input::new(&[i + 1]).unwrap();
+                (input, secret.output(input))
+            })
+            .collect();
+
+        let proof = secret.prove_multi(&ios, b"bar");
+        assert!(public.verify_multi(&ios, b"bar", &proof).is_ok());
+
+        // Tamper: wrong output on ios[1]
+        let mut bad_ios = ios.clone();
+        bad_ios[1].1 = secret.output(ios[0].0); // wrong output for that input
+        assert!(public.verify_multi(&bad_ios, b"bar", &proof).is_err());
+
+        // Tamper: wrong input on ios[0]
+        let mut bad_ios = ios.clone();
+        bad_ios[0].0 = ios[1].0;
+        assert!(public.verify_multi(&bad_ios, b"bar", &proof).is_err());
+
+        // Tamper: wrong ad
+        assert!(public.verify_multi(&ios, b"baz", &proof).is_err());
+    }
+
+    pub fn prove_verify_multi_empty<S: IetfSuite>() {
+        let secret = Secret::<S>::from_seed(common::TEST_SEED);
+        let public = secret.public();
+        let proof = secret.prove_multi(&[], b"bar");
+
+        assert!(public.verify_multi(&[], b"bar", &proof).is_ok());
+        assert!(public.verify_multi(&[], b"baz", &proof).is_err());
+    }
+
     #[macro_export]
     macro_rules! ietf_suite_tests {
         ($suite:ty) => {
@@ -232,6 +358,21 @@ pub mod testing {
                 #[test]
                 fn prove_verify() {
                     $crate::ietf::testing::prove_verify::<$suite>();
+                }
+
+                #[test]
+                fn prove_verify_multi_single() {
+                    $crate::ietf::testing::prove_verify_multi_single::<$suite>();
+                }
+
+                #[test]
+                fn prove_verify_multi() {
+                    $crate::ietf::testing::prove_verify_multi::<$suite>();
+                }
+
+                #[test]
+                fn prove_verify_multi_empty() {
+                    $crate::ietf::testing::prove_verify_multi_empty::<$suite>();
                 }
 
                 $crate::test_vectors!($crate::ietf::testing::TestVector<$suite>);

--- a/src/ietf.rs
+++ b/src/ietf.rs
@@ -104,11 +104,40 @@ impl<S: IetfSuite> ark_serialize::Valid for Proof<S> {
     }
 }
 
+/// Delinearize and merge multiple input-output pairs into a single pair.
+///
+/// - N=0: returns the identity point for both input and output.
+/// - N=1: returns the pair as-is, no delinearization.
+/// - N>1: derives 128-bit delinearization scalars and returns
+///   `(sum(z_i * H_i), sum(z_i * Gamma_i))`.
+fn merge<S: IetfSuite>(
+    pk: &Public<S>,
+    ios: &[(Input<S>, Output<S>)],
+    ad: &[u8],
+) -> (Input<S>, Output<S>) {
+    if ios.len() == 1 {
+        return (ios[0].0, ios[0].1);
+    }
+
+    let zs = utils::delinearization_scalars::<S>(&pk.0, ios, ad);
+
+    type Projective<S> = <AffinePoint<S> as AffineRepr>::Group;
+    let (input, output) = ios.iter().zip(zs.iter()).fold(
+        (Projective::<S>::zero(), Projective::<S>::zero()),
+        |(h_acc, g_acc), ((i, o), z)| (h_acc + i.0 * z, g_acc + o.0 * z),
+    );
+    let norms = CurveGroup::normalize_batch(&[input, output]);
+    (Input(norms[0]), Output(norms[1]))
+}
+
 /// Trait for types that can generate VRF proofs.
 ///
 /// Implementors can create cryptographic proofs that a VRF output
 /// is correctly derived from an input using their secret key.
 pub trait Prover<S: IetfSuite> {
+    /// The public key associated with this prover.
+    fn public_key(&self) -> Public<S>;
+
     /// Generate a proof for the given input/output and additional data.
     ///
     /// Creates a non-interactive zero-knowledge proof binding the input, output,
@@ -118,6 +147,19 @@ pub trait Prover<S: IetfSuite> {
     /// * `output` - VRF output point (γ = x·H)
     /// * `ad` - Additional data to bind to the proof
     fn prove(&self, input: Input<S>, output: Output<S>, ad: impl AsRef<[u8]>) -> Proof<S>;
+
+    /// Generate a proof for multiple input-output pairs using delinearized DLEQ.
+    ///
+    /// When `ios` has a single element, the proof is byte-identical to [`Prover::prove`].
+    /// For N>1, delinearization scalars merge all input-output pairs into a single
+    /// DLEQ proof, amortizing proof size.
+    ///
+    /// When `ios` is empty, the merged input and output are both the identity point,
+    /// reducing to a Schnorr signature over the additional data.
+    fn prove_multi(&self, ios: &[(Input<S>, Output<S>)], ad: impl AsRef<[u8]>) -> Proof<S> {
+        let (input, output) = merge(&self.public_key(), ios, ad.as_ref());
+        self.prove(input, output, ad)
+    }
 }
 
 /// Trait for entities that can verify VRF proofs.
@@ -125,6 +167,9 @@ pub trait Prover<S: IetfSuite> {
 /// Implementors can verify that a VRF output is correctly derived
 /// from an input using a specific public key.
 pub trait Verifier<S: IetfSuite> {
+    /// The public key associated with this verifier.
+    fn public_key(&self) -> Public<S>;
+
     /// Verify a proof for the given input/output and additional data.
     ///
     /// Verifies the cryptographic relationship between input, output, and proof
@@ -143,9 +188,30 @@ pub trait Verifier<S: IetfSuite> {
         aux: impl AsRef<[u8]>,
         proof: &Proof<S>,
     ) -> Result<(), Error>;
+
+    /// Verify a proof for multiple input-output pairs using delinearized DLEQ.
+    ///
+    /// When `ios` has a single element, delegates to [`Verifier::verify`].
+    /// For N>1, recomputes delinearization scalars and verifies the merged DLEQ.
+    ///
+    /// When `ios` is empty, the merged input and output are both the identity point,
+    /// reducing to a Schnorr signature verification over the additional data.
+    fn verify_multi(
+        &self,
+        ios: &[(Input<S>, Output<S>)],
+        ad: impl AsRef<[u8]>,
+        proof: &Proof<S>,
+    ) -> Result<(), Error> {
+        let (input, output) = merge(&self.public_key(), ios, ad.as_ref());
+        self.verify(input, output, ad, proof)
+    }
 }
 
 impl<S: IetfSuite> Prover<S> for Secret<S> {
+    fn public_key(&self) -> Public<S> {
+        self.public
+    }
+
     /// Implements the IETF VRF proving algorithm.
     ///
     /// This follows the procedure specified in RFC-9381 section 5.1, with extensions
@@ -174,6 +240,10 @@ impl<S: IetfSuite> Prover<S> for Secret<S> {
 }
 
 impl<S: IetfSuite> Verifier<S> for Public<S> {
+    fn public_key(&self) -> Public<S> {
+        *self
+    }
+
     /// Implements the IETF VRF verification algorithm.
     ///
     /// This follows the procedure specified in RFC-9381 section 5.3, with extensions
@@ -202,66 +272,6 @@ impl<S: IetfSuite> Verifier<S> for Public<S> {
         (&c_exp == c)
             .then_some(())
             .ok_or(Error::VerificationFailure)
-    }
-}
-
-/// Delinearize and merge multiple input-output pairs into a single pair.
-///
-/// - N=0: returns the identity point for both input and output.
-/// - N=1: returns the pair as-is, no delinearization.
-/// - N>1: derives 128-bit delinearization scalars and returns
-///   `(sum(z_i * H_i), sum(z_i * Gamma_i))`.
-fn merge<S: IetfSuite>(
-    pk: &Public<S>,
-    ios: &[(Input<S>, Output<S>)],
-    ad: &[u8],
-) -> (Input<S>, Output<S>) {
-    if ios.len() == 1 {
-        return (ios[0].0, ios[0].1);
-    }
-
-    let zs = utils::delinearization_scalars::<S>(&pk.0, ios, ad);
-
-    type Projective<S> = <AffinePoint<S> as AffineRepr>::Group;
-    let (input, output) = ios.iter().zip(zs.iter()).fold(
-        (Projective::<S>::zero(), Projective::<S>::zero()),
-        |(h_acc, g_acc), ((i, o), z)| (h_acc + i.0 * z, g_acc + o.0 * z),
-    );
-    let norms = CurveGroup::normalize_batch(&[input, output]);
-    (Input(norms[0]), Output(norms[1]))
-}
-
-impl<S: IetfSuite> Secret<S> {
-    /// Generate a proof for multiple input-output pairs using delinearized DLEQ.
-    ///
-    /// When `ios` has a single element, the proof is byte-identical to [`Prover::prove`].
-    /// For N>1, delinearization scalars merge all input-output pairs into a single
-    /// DLEQ proof, amortizing proof size.
-    ///
-    /// When `ios` is empty, the merged input and output are both the identity point,
-    /// reducing to a Schnorr signature over the additional data.
-    pub fn prove_multi(&self, ios: &[(Input<S>, Output<S>)], ad: impl AsRef<[u8]>) -> Proof<S> {
-        let (input, output) = merge(&self.public, ios, ad.as_ref());
-        Prover::prove(self, input, output, ad)
-    }
-}
-
-impl<S: IetfSuite> Public<S> {
-    /// Verify a proof for multiple input-output pairs using delinearized DLEQ.
-    ///
-    /// When `ios` has a single element, delegates to [`Verifier::verify`].
-    /// For N>1, recomputes delinearization scalars and verifies the merged DLEQ.
-    ///
-    /// When `ios` is empty, the merged input and output are both the identity point,
-    /// reducing to a Schnorr signature verification over the additional data.
-    pub fn verify_multi(
-        &self,
-        ios: &[(Input<S>, Output<S>)],
-        ad: impl AsRef<[u8]>,
-        proof: &Proof<S>,
-    ) -> Result<(), Error> {
-        let (input, output) = merge(self, ios, ad.as_ref());
-        Verifier::verify(self, input, output, ad, proof)
     }
 }
 

--- a/src/ietf.rs
+++ b/src/ietf.rs
@@ -211,7 +211,7 @@ pub mod testing {
     use crate::testing::{self as common, SuiteExt};
 
     fn merge<S: IetfSuite>(ios: &[(Input<S>, Output<S>)], ad: &[u8]) -> (Input<S>, Output<S>) {
-        utils::merge::<S>(123, ios, ad)
+        utils::delinearize::<S>(123, ios, ad)
     }
 
     pub fn prove_verify<S: IetfSuite>() {

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -442,7 +442,7 @@ pub(crate) mod testing {
     use crate::testing::{self as common, random_val, CheckPoint, SuiteExt, TEST_SEED};
 
     fn merge<S: PedersenSuite>(ios: &[(Input<S>, Output<S>)], ad: &[u8]) -> (Input<S>, Output<S>) {
-        utils::merge::<S>(123, ios, ad)
+        utils::delinearize::<S>(123, ios, ad)
     }
 
     pub fn prove_verify<S: PedersenSuite>() {

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -439,7 +439,7 @@ impl<S: PedersenSuite> BatchVerifier<S> {
 #[cfg(test)]
 pub(crate) mod testing {
     use super::*;
-    use crate::testing::{self as common, random_val, CheckPoint, SuiteExt, TEST_SEED};
+    use crate::testing::{self as common, CheckPoint, SuiteExt, TEST_SEED, random_val};
 
     fn merge<S: PedersenSuite>(ios: &[(Input<S>, Output<S>)], ad: &[u8]) -> (Input<S>, Output<S>) {
         utils::delinearize::<S>(123, ios, ad)

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -56,12 +56,11 @@ pub trait PedersenSuite: IetfSuite {
         aux: &[u8],
     ) -> ScalarField<Self> {
         use digest::Digest;
-        const DOM_SEP_START: u8 = 0xCC;
-        const DOM_SEP_END: u8 = 0x00;
+        use crate::utils::common::DomSep;
         let mut buf = Vec::with_capacity(Self::Codec::POINT_ENCODED_LEN);
         let hash = Self::Hasher::new()
             .chain_update(Self::SUITE_ID)
-            .chain_update([DOM_SEP_START])
+            .chain_update([DomSep::PedersenBlinding as u8])
             .chain_update({
                 Self::Codec::scalar_encode_into(secret, &mut buf);
                 &buf
@@ -72,7 +71,7 @@ pub trait PedersenSuite: IetfSuite {
                 &buf
             })
             .chain_update(aux)
-            .chain_update([DOM_SEP_END])
+            .chain_update([DomSep::End as u8])
             .finalize();
         codec::scalar_decode::<Self>(&hash)
     }
@@ -442,7 +441,7 @@ pub(crate) mod testing {
     use crate::testing::{self as common, CheckPoint, SuiteExt, TEST_SEED, random_val};
 
     fn merge<S: PedersenSuite>(ios: &[(Input<S>, Output<S>)], ad: &[u8]) -> (Input<S>, Output<S>) {
-        utils::delinearize::<S>(123, ios, ad)
+        utils::delinearize::<S>(ios, ad)
     }
 
     pub fn prove_verify<S: PedersenSuite>() {

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -55,8 +55,8 @@ pub trait PedersenSuite: IetfSuite {
         input: &AffinePoint<Self>,
         aux: &[u8],
     ) -> ScalarField<Self> {
-        use digest::Digest;
         use crate::utils::common::DomSep;
+        use digest::Digest;
         let mut buf = Vec::with_capacity(Self::Codec::POINT_ENCODED_LEN);
         let hash = Self::Hasher::new()
             .chain_update(Self::SUITE_ID)

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -439,7 +439,11 @@ impl<S: PedersenSuite> BatchVerifier<S> {
 #[cfg(test)]
 pub(crate) mod testing {
     use super::*;
-    use crate::testing::{self as common, CheckPoint, SuiteExt, TEST_SEED, random_val};
+    use crate::testing::{self as common, random_val, CheckPoint, SuiteExt, TEST_SEED};
+
+    fn merge<S: PedersenSuite>(ios: &[(Input<S>, Output<S>)], ad: &[u8]) -> (Input<S>, Output<S>) {
+        utils::merge::<S>(123, ios, ad)
+    }
 
     pub fn prove_verify<S: PedersenSuite>() {
         use pedersen::{Prover, Verifier};
@@ -497,6 +501,84 @@ pub(crate) mod testing {
         assert!(batch.verify().is_err());
     }
 
+    /// N=1 merge + prove must be byte-identical to standard prove,
+    /// and cross-verification works in both directions.
+    pub fn prove_verify_multi_single<S: PedersenSuite>() {
+        use pedersen::{Prover, Verifier};
+
+        let secret = Secret::<S>::from_seed(TEST_SEED);
+        let input = Input::from_affine(random_val(None));
+        let output = secret.output(input);
+
+        let (proof_std, blinding_std) = secret.prove(input, output, b"foo");
+        let io = (input, output);
+        let (mi, mo) = merge(&[io], b"foo");
+        let (proof_multi, blinding_multi) = secret.prove(mi, mo, b"foo");
+
+        // Byte-identical proofs and blinding factors
+        let encode = |p: &pedersen::Proof<S>| {
+            let mut buf = Vec::new();
+            p.serialize_compressed(&mut buf).unwrap();
+            buf
+        };
+        assert_eq!(encode(&proof_std), encode(&proof_multi));
+        assert_eq!(blinding_std, blinding_multi);
+
+        // Cross-verification
+        assert!(Public::verify(input, output, b"foo", &proof_multi).is_ok());
+        assert!(Public::verify(mi, mo, b"foo", &proof_std).is_ok());
+    }
+
+    /// N=3 multi proof: verify succeeds; tampered output/input/ad fails.
+    pub fn prove_verify_multi<S: PedersenSuite>() {
+        use pedersen::{Prover, Verifier};
+
+        let secret = Secret::<S>::from_seed(TEST_SEED);
+
+        let mut ios: Vec<(Input<S>, Output<S>)> = (0..3u8)
+            .map(|i| {
+                let input = Input::new(&[i + 1]).unwrap();
+                (input, secret.output(input))
+            })
+            .collect();
+        ios.push((Input(S::Affine::generator()), Output(secret.public().0)));
+
+        let (input, output) = merge(&ios, b"bar");
+        let (proof, _) = secret.prove(input, output, b"bar");
+        assert!(Public::verify(input, output, b"bar", &proof).is_ok());
+
+        // Tamper: wrong output on ios[1]
+        let mut bad_ios = ios.clone();
+        bad_ios[1].1 = secret.output(ios[0].0);
+        let (bi, bo) = merge(&bad_ios, b"bar");
+        assert!(Public::verify(bi, bo, b"bar", &proof).is_err());
+
+        // Tamper: wrong input on ios[0]
+        let mut bad_ios = ios.clone();
+        bad_ios[0].0 = ios[1].0;
+        let (bi, bo) = merge(&bad_ios, b"bar");
+        assert!(Public::verify(bi, bo, b"bar", &proof).is_err());
+
+        // Tamper: wrong ad
+        let (bi, bo) = merge(&ios, b"baz");
+        assert!(Public::verify(bi, bo, b"baz", &proof).is_err());
+    }
+
+    /// N=0 reduces to a Schnorr signature over the additional data.
+    pub fn prove_verify_multi_empty<S: PedersenSuite>() {
+        use pedersen::{Prover, Verifier};
+
+        let secret = Secret::<S>::from_seed(TEST_SEED);
+
+        let (input, output) = merge(&[], b"bar");
+        let (proof, _) = secret.prove(input, output, b"bar");
+
+        assert!(Public::verify(input, output, b"bar", &proof).is_ok());
+
+        let (bi, bo) = merge(&[], b"baz");
+        assert!(Public::verify(bi, bo, b"baz", &proof).is_err());
+    }
+
     pub fn blinding_base_check<S: PedersenSuite>()
     where
         AffinePoint<S>: CheckPoint,
@@ -519,6 +601,21 @@ pub(crate) mod testing {
                 #[test]
                 fn prove_verify() {
                     $crate::pedersen::testing::prove_verify::<$suite>();
+                }
+
+                #[test]
+                fn prove_verify_multi_single() {
+                    $crate::pedersen::testing::prove_verify_multi_single::<$suite>();
+                }
+
+                #[test]
+                fn prove_verify_multi() {
+                    $crate::pedersen::testing::prove_verify_multi::<$suite>();
+                }
+
+                #[test]
+                fn prove_verify_multi_empty() {
+                    $crate::pedersen::testing::prove_verify_multi_empty::<$suite>();
                 }
 
                 #[test]

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -866,6 +866,57 @@ pub(crate) mod testing {
         assert!(result.is_ok());
     }
 
+    fn delinearize<S: RingSuite>(
+        ios: &[(Input<S>, Output<S>)],
+        ad: &[u8],
+    ) -> (Input<S>, Output<S>) {
+        utils::delinearize::<S>(123, ios, ad)
+    }
+
+    /// N=3 multi proof via delinearize + ring prove/verify.
+    #[allow(unused)]
+    pub fn prove_verify_multi<S: RingSuite>() {
+        use ring::{Prover, Verifier};
+
+        let rng = &mut ark_std::test_rng();
+        let params = RingProofParams::<S>::from_rand(TEST_RING_SIZE, rng);
+
+        let secret = Secret::<S>::from_seed(TEST_SEED);
+        let public = secret.public();
+
+        let mut pks = common::random_vec::<AffinePoint<S>>(TEST_RING_SIZE, Some(rng));
+        let prover_idx = 3;
+        pks[prover_idx] = public.0;
+
+        let prover_key = params.prover_key(&pks);
+        let prover = params.prover(prover_key, prover_idx);
+
+        let verifier_key = params.verifier_key(&pks);
+        let verifier = params.verifier(verifier_key);
+
+        let mut ios: Vec<(Input<S>, Output<S>)> = (0..3u8)
+            .map(|i| {
+                let input = Input::new(&[i + 1]).unwrap();
+                (input, secret.output(input))
+            })
+            .collect();
+        ios.push((Input(S::Affine::generator()), Output(public.0)));
+
+        let (input, output) = delinearize(&ios, b"bar");
+        let proof = secret.prove(input, output, b"bar", &prover);
+        assert!(Public::verify(input, output, b"bar", &proof, &verifier).is_ok());
+
+        // Tamper: wrong output on ios[1]
+        let mut bad_ios = ios.clone();
+        bad_ios[1].1 = secret.output(ios[0].0);
+        let (bi, bo) = delinearize(&bad_ios, b"bar");
+        assert!(Public::verify(bi, bo, b"bar", &proof, &verifier).is_err());
+
+        // Tamper: wrong ad
+        let (bi, bo) = delinearize(&ios, b"baz");
+        assert!(Public::verify(bi, bo, b"baz", &proof, &verifier).is_err());
+    }
+
     #[allow(unused)]
     pub fn prove_verify_batch<S: RingSuite>() {
         use rayon::prelude::*;
@@ -1092,6 +1143,11 @@ pub(crate) mod testing {
                 #[test]
                 fn prove_verify() {
                     $crate::ring::testing::prove_verify::<$suite>()
+                }
+
+                #[test]
+                fn prove_verify_multi() {
+                    $crate::ring::testing::prove_verify_multi::<$suite>()
                 }
 
                 #[test]

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -870,7 +870,7 @@ pub(crate) mod testing {
         ios: &[(Input<S>, Output<S>)],
         ad: &[u8],
     ) -> (Input<S>, Output<S>) {
-        utils::delinearize::<S>(123, ios, ad)
+        utils::delinearize::<S>(ios, ad)
     }
 
     /// N=3 multi proof via delinearize + ring prove/verify.

--- a/src/utils/common.rs
+++ b/src/utils/common.rs
@@ -6,8 +6,8 @@
 
 use crate::*;
 use ark_ec::{
-    hashing::curve_maps::elligator2::{Elligator2Config, Elligator2Map},
     AffineRepr,
+    hashing::curve_maps::elligator2::{Elligator2Config, Elligator2Map},
 };
 use digest::{Digest, FixedOutputReset};
 
@@ -113,7 +113,7 @@ where
     Elligator2Map<CurveConfig<S>>:
         ark_ec::hashing::map_to_curve_hasher::MapToCurve<<AffinePoint<S> as AffineRepr>::Group>,
 {
-    use ark_ec::hashing::{map_to_curve_hasher::MapToCurveBasedHasher, HashToCurve};
+    use ark_ec::hashing::{HashToCurve, map_to_curve_hasher::MapToCurveBasedHasher};
     use ark_ff::field_hashers::DefaultFieldHasher;
 
     // Domain Separation Tag := "ECVRF_" || h2c_suite_ID_string || suite_string

--- a/src/utils/common.rs
+++ b/src/utils/common.rs
@@ -357,6 +357,15 @@ where
 /// - N=1: returns the pair as-is, no hashing or scalar multiplications.
 /// - N>1: derives per-pair 128-bit scalars (2^{-128} Schwartz-Zippel soundness)
 ///   and returns their linear combination.
+///
+/// # WARNING: N=0
+///
+/// When `ios` is empty, both returned points are the identity (zero point).
+/// Since `sk * O = O` for every secret key, the resulting DLEQ proof degenerates
+/// into a Schnorr signature over the additional data -- it binds the public key
+/// to `ad` but provides **no VRF output**. The `Output` is a public constant
+/// (the identity point) and **must not** be used to derive VRF randomness.
+/// Doing so would produce a predictable, key-independent value.
 pub fn delinearize<S: Suite>(
     dom_sep: u8,
     ios: &[(Input<S>, Output<S>)],

--- a/src/utils/common.rs
+++ b/src/utils/common.rs
@@ -394,15 +394,19 @@ pub fn delinearize<S: Suite>(
     hasher.update([DOM_SEP_BACK]);
     let seed = hasher.finalize();
 
-    // Derive z_i = H(seed || i_le) truncated to 128 bits, accumulate on the fly.
-    let (input, output) = ios.iter().enumerate().fold(
+    // Seed a ChaCha20Rng from the hash, then draw 128-bit scalars on the fly.
+    use ark_std::rand::{RngCore, SeedableRng};
+    let mut rng_seed = [0u8; 32];
+    let copy_len = seed.len().min(32);
+    rng_seed[..copy_len].copy_from_slice(&seed[..copy_len]);
+    let mut rng = rand_chacha::ChaCha20Rng::from_seed(rng_seed);
+
+    let (input, output) = ios.iter().fold(
         (zero.into_group(), zero.into_group()),
-        |(h_acc, g_acc), (i, (inp, out))| {
-            let h = S::Hasher::new()
-                .chain_update(&seed)
-                .chain_update((i as u32).to_le_bytes())
-                .finalize();
-            let z = ScalarField::<S>::from_le_bytes_mod_order(&h[..16]);
+        |(h_acc, g_acc), (inp, out)| {
+            let mut buf = [0u8; 16];
+            rng.fill_bytes(&mut buf);
+            let z = ScalarField::<S>::from_le_bytes_mod_order(&buf);
             (h_acc + inp.0 * z, g_acc + out.0 * z)
         },
     );

--- a/src/utils/common.rs
+++ b/src/utils/common.rs
@@ -6,8 +6,8 @@
 
 use crate::*;
 use ark_ec::{
-    AffineRepr,
     hashing::curve_maps::elligator2::{Elligator2Config, Elligator2Map},
+    AffineRepr,
 };
 use digest::{Digest, FixedOutputReset};
 
@@ -113,7 +113,7 @@ where
     Elligator2Map<CurveConfig<S>>:
         ark_ec::hashing::map_to_curve_hasher::MapToCurve<<AffinePoint<S> as AffineRepr>::Group>,
 {
-    use ark_ec::hashing::{HashToCurve, map_to_curve_hasher::MapToCurveBasedHasher};
+    use ark_ec::hashing::{map_to_curve_hasher::MapToCurveBasedHasher, HashToCurve};
     use ark_ff::field_hashers::DefaultFieldHasher;
 
     // Domain Separation Tag := "ECVRF_" || h2c_suite_ID_string || suite_string
@@ -374,7 +374,7 @@ pub fn delinearize<S: Suite>(
 
     // Seed: H(suite_id || dom_sep || N || encode(H_0) || encode(Gamma_0) || ... || ad || 0x00)
     const DOM_SEP_BACK: u8 = 0x00;
-    let n = ios.len() as u32;
+    let n = u32::try_from(ios.len()).expect("too many input-output pairs");
 
     let mut hasher = S::Hasher::new();
     hasher.update(S::SUITE_ID);
@@ -396,20 +396,43 @@ pub fn delinearize<S: Suite>(
 
     // Seed a ChaCha20Rng from the hash, then draw 128-bit scalars on the fly.
     use ark_std::rand::{RngCore, SeedableRng};
+    assert!(seed.len() >= 32, "hash output too short for ChaCha20 seed");
     let mut rng_seed = [0u8; 32];
-    let copy_len = seed.len().min(32);
-    rng_seed[..copy_len].copy_from_slice(&seed[..copy_len]);
+    rng_seed.copy_from_slice(&seed[..32]);
     let mut rng = rand_chacha::ChaCha20Rng::from_seed(rng_seed);
 
-    let (input, output) = ios.iter().fold(
-        (zero.into_group(), zero.into_group()),
-        |(h_acc, g_acc), (inp, out)| {
-            let mut buf = [0u8; 16];
-            rng.fill_bytes(&mut buf);
-            let z = ScalarField::<S>::from_le_bytes_mod_order(&buf);
+    // MSM has bucket-setup overhead that dominates for small N.
+    // Fold is faster below this threshold; MSM wins above it.
+    const MSM_THRESHOLD: usize = 16;
+
+    let mut next_scalar = || {
+        let mut buf = [0u8; 16];
+        rng.fill_bytes(&mut buf);
+        S::Codec::scalar_decode(&buf)
+    };
+
+    let zero = zero.into_group();
+    let (input, output) = if ios.len() < MSM_THRESHOLD {
+        ios.iter().fold((zero, zero), |(h_acc, g_acc), (inp, out)| {
+            let z = next_scalar();
             (h_acc + inp.0 * z, g_acc + out.0 * z)
-        },
-    );
+        })
+    } else {
+        let n = ios.len();
+        let mut scalars = Vec::with_capacity(n);
+        let mut inputs = Vec::with_capacity(n);
+        let mut outputs = Vec::with_capacity(n);
+        for (inp, out) in ios {
+            scalars.push(next_scalar());
+            inputs.push(inp.0);
+            outputs.push(out.0);
+        }
+        use ark_ec::VariableBaseMSM;
+        type Group<S> = <AffinePoint<S> as AffineRepr>::Group;
+        let input = Group::<S>::msm_unchecked(&inputs, &scalars);
+        let output = Group::<S>::msm_unchecked(&outputs, &scalars);
+        (input, output)
+    };
     let norms = CurveGroup::normalize_batch(&[input, output]);
     (Input(norms[0]), Output(norms[1]))
 }

--- a/src/utils/common.rs
+++ b/src/utils/common.rs
@@ -79,7 +79,10 @@ pub fn hash_to_curve_tai_rfc_9381<S: Suite>(data: &[u8]) -> Option<AffinePoint<S
         .chain_update(data);
 
     for ctr in 0..=255u8 {
-        let hash = prefix.clone().chain_update([ctr, DomSep::End as u8]).finalize();
+        let hash = prefix
+            .clone()
+            .chain_update([ctr, DomSep::End as u8])
+            .finalize();
         if let Ok(pt) = codec::point_decode::<S>(&hash[..]) {
             let pt = pt.clear_cofactor();
             if !pt.is_zero() {
@@ -372,10 +375,7 @@ where
 /// to `ad` but provides **no VRF output**. The `Output` is a public constant
 /// (the identity point) and **must not** be used to derive VRF randomness.
 /// Doing so would produce a predictable, key-independent value.
-pub fn delinearize<S: Suite>(
-    ios: &[(Input<S>, Output<S>)],
-    ad: &[u8],
-) -> (Input<S>, Output<S>) {
+pub fn delinearize<S: Suite>(ios: &[(Input<S>, Output<S>)], ad: &[u8]) -> (Input<S>, Output<S>) {
     let zero = AffinePoint::<S>::zero();
 
     if ios.is_empty() {

--- a/src/utils/common.rs
+++ b/src/utils/common.rs
@@ -11,6 +11,17 @@ use ark_ec::{
 };
 use digest::{Digest, FixedOutputReset};
 
+/// Internal domain separation tags for protocol hashing.
+#[repr(u8)]
+pub(crate) enum DomSep {
+    HashToCurveTai = 0x01,
+    Challenge = 0x02,
+    PointToHash = 0x03,
+    Delinearize = 0x04,
+    PedersenBlinding = 0xCC,
+    End = 0x00,
+}
+
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
 
@@ -62,16 +73,13 @@ fn hmac<H: Digest + digest::core_api::BlockSizeUser>(sk: &[u8], data: &[u8]) -> 
 pub fn hash_to_curve_tai_rfc_9381<S: Suite>(data: &[u8]) -> Option<AffinePoint<S>> {
     use ark_ec::AffineRepr;
 
-    const DOM_SEP_FRONT: u8 = 0x01;
-    const DOM_SEP_BACK: u8 = 0x00;
-
     let prefix = S::Hasher::new()
         .chain_update(S::SUITE_ID)
-        .chain_update([DOM_SEP_FRONT])
+        .chain_update([DomSep::HashToCurveTai as u8])
         .chain_update(data);
 
     for ctr in 0..=255u8 {
-        let hash = prefix.clone().chain_update([ctr, DOM_SEP_BACK]).finalize();
+        let hash = prefix.clone().chain_update([ctr, DomSep::End as u8]).finalize();
         if let Ok(pt) = codec::point_decode::<S>(&hash[..]) {
             let pt = pt.clear_cofactor();
             if !pt.is_zero() {
@@ -148,11 +156,9 @@ where
 ///
 /// A scalar field element derived from the hash of the inputs
 pub fn challenge_rfc_9381<S: Suite>(pts: &[&AffinePoint<S>], ad: &[u8]) -> ScalarField<S> {
-    const DOM_SEP_START: u8 = 0x02;
-    const DOM_SEP_END: u8 = 0x00;
     let mut hasher = S::Hasher::new();
     hasher.update(S::SUITE_ID);
-    hasher.update([DOM_SEP_START]);
+    hasher.update([DomSep::Challenge as u8]);
     let mut pt_buf = Vec::with_capacity(S::Codec::POINT_ENCODED_LEN);
     for p in pts {
         pt_buf.clear();
@@ -160,7 +166,7 @@ pub fn challenge_rfc_9381<S: Suite>(pts: &[&AffinePoint<S>], ad: &[u8]) -> Scala
         hasher.update(&pt_buf);
     }
     hasher.update(ad);
-    hasher.update([DOM_SEP_END]);
+    hasher.update([DomSep::End as u8]);
     let hash = hasher.finalize();
     codec::scalar_decode::<S>(&hash[..S::CHALLENGE_LEN])
 }
@@ -195,19 +201,17 @@ pub fn point_to_hash_rfc_9381<S: Suite>(
     mul_by_cofactor: bool,
 ) -> HashOutput<S> {
     use ark_std::borrow::Cow::*;
-    const DOM_SEP_START: u8 = 0x03;
-    const DOM_SEP_END: u8 = 0x00;
     let pt = match mul_by_cofactor {
         false => Borrowed(pt),
         true => Owned(pt.mul_by_cofactor()),
     };
     let mut hasher = S::Hasher::new();
     hasher.update(S::SUITE_ID);
-    hasher.update([DOM_SEP_START]);
+    hasher.update([DomSep::PointToHash as u8]);
     let mut pt_buf = Vec::with_capacity(S::Codec::POINT_ENCODED_LEN);
     S::Codec::point_encode_into(&pt, &mut pt_buf);
     hasher.update(&pt_buf);
-    hasher.update([DOM_SEP_END]);
+    hasher.update([DomSep::End as u8]);
     hasher.finalize()
 }
 
@@ -351,8 +355,6 @@ where
 /// The resulting `(Input, Output)` can be passed directly to a scheme's
 /// `prove` / `verify` to obtain or check a single proof covering all pairs.
 ///
-/// The `dom_sep` byte allows callers to domain-separate different schemes.
-///
 /// The ordering of `ios` matters: the delinearization scalars are derived from
 /// the hash of the pairs in the given order, so the prover and verifier must
 /// use the same ordering to obtain the same merged pair.
@@ -371,7 +373,6 @@ where
 /// (the identity point) and **must not** be used to derive VRF randomness.
 /// Doing so would produce a predictable, key-independent value.
 pub fn delinearize<S: Suite>(
-    dom_sep: u8,
     ios: &[(Input<S>, Output<S>)],
     ad: &[u8],
 ) -> (Input<S>, Output<S>) {
@@ -386,12 +387,11 @@ pub fn delinearize<S: Suite>(
     }
 
     // Seed: H(suite_id || dom_sep || N || encode(H_0) || encode(Gamma_0) || ... || ad || 0x00)
-    const DOM_SEP_BACK: u8 = 0x00;
     let n = u32::try_from(ios.len()).expect("too many input-output pairs");
 
     let mut hasher = S::Hasher::new();
     hasher.update(S::SUITE_ID);
-    hasher.update([dom_sep]);
+    hasher.update([DomSep::Delinearize as u8]);
     hasher.update(n.to_le_bytes());
 
     let mut pt_buf = Vec::with_capacity(S::Codec::POINT_ENCODED_LEN);
@@ -404,7 +404,7 @@ pub fn delinearize<S: Suite>(
         hasher.update(&pt_buf);
     }
     hasher.update(ad);
-    hasher.update([DOM_SEP_BACK]);
+    hasher.update([DomSep::End as u8]);
     let seed = hasher.finalize();
 
     // Seed a ChaCha20Rng from the hash, then draw 128-bit scalars on the fly.

--- a/src/utils/common.rs
+++ b/src/utils/common.rs
@@ -6,8 +6,8 @@
 
 use crate::*;
 use ark_ec::{
-    AffineRepr,
     hashing::curve_maps::elligator2::{Elligator2Config, Elligator2Map},
+    AffineRepr,
 };
 use digest::{Digest, FixedOutputReset};
 
@@ -113,7 +113,7 @@ where
     Elligator2Map<CurveConfig<S>>:
         ark_ec::hashing::map_to_curve_hasher::MapToCurve<<AffinePoint<S> as AffineRepr>::Group>,
 {
-    use ark_ec::hashing::{HashToCurve, map_to_curve_hasher::MapToCurveBasedHasher};
+    use ark_ec::hashing::{map_to_curve_hasher::MapToCurveBasedHasher, HashToCurve};
     use ark_ff::field_hashers::DefaultFieldHasher;
 
     // Domain Separation Tag := "ECVRF_" || h2c_suite_ID_string || suite_string
@@ -349,26 +349,23 @@ where
 /// Derives per-input scalars using the technique from Privacy Pass / dleq_vrf.
 /// Each scalar is 128-bit, providing 2^{-128} Schwartz-Zippel soundness.
 ///
-/// Uses domain separator `0x04` (unused by TAI=0x01, challenge=0x02, point_to_hash=0x03).
+/// The `dom_sep` byte allows callers to domain-separate different schemes.
+///
+/// Seed: `H(suite_id || dom_sep || N || encode(H_0) || encode(Gamma_0) || ... || ad || 0x00)`
 pub fn delinearization_scalars<S: Suite>(
-    pk: &AffinePoint<S>,
+    dom_sep: u8,
     ios: &[(Input<S>, Output<S>)],
     ad: &[u8],
 ) -> Vec<ScalarField<S>> {
-    const DOM_SEP_FRONT: u8 = 0x04;
     const DOM_SEP_BACK: u8 = 0x00;
 
-    let n = ios.len() as u32;
-
-    // Seed: H(suite_id || 0x04 || encode(pk) || N || encode(H_0) || encode(Gamma_0) || ... || ad || 0x00)
     let mut hasher = S::Hasher::new();
     hasher.update(S::SUITE_ID);
-    hasher.update([DOM_SEP_FRONT]);
+    hasher.update([dom_sep]);
 
     let mut pt_buf = Vec::with_capacity(S::Codec::POINT_ENCODED_LEN);
-    S::Codec::point_encode_into(pk, &mut pt_buf);
-    hasher.update(&pt_buf);
 
+    let n = ios.len() as u32;
     hasher.update(n.to_le_bytes());
 
     for (input, output) in ios {
@@ -394,6 +391,39 @@ pub fn delinearization_scalars<S: Suite>(
             ScalarField::<S>::from_le_bytes_mod_order(&h[..16])
         })
         .collect()
+}
+
+/// Delinearize and merge multiple input-output pairs into a single pair.
+///
+/// The resulting `(Input, Output)` can be passed directly to a scheme's
+/// `prove` / `verify` to obtain or check a single proof covering all pairs.
+///
+/// - N=0: returns the identity point for both input and output.
+/// - N=1: returns the pair as-is, no delinearization.
+/// - N>1: derives 128-bit delinearization scalars and returns
+///   `(sum(z_i * H_i), sum(z_i * Gamma_i))`.
+pub fn merge<S: Suite>(
+    dom_sep: u8,
+    ios: &[(Input<S>, Output<S>)],
+    ad: &[u8],
+) -> (Input<S>, Output<S>) {
+    let zero = AffinePoint::<S>::zero();
+
+    if ios.is_empty() {
+        return (Input(zero), Output(zero));
+    }
+
+    if ios.len() == 1 {
+        return (ios[0].0, ios[0].1);
+    }
+
+    let zs = delinearization_scalars::<S>(dom_sep, ios, ad);
+    let (input, output) = ios.iter().zip(zs.iter()).fold(
+        (zero.into_group(), zero.into_group()),
+        |(h_acc, g_acc), ((i, o), z)| (h_acc + i.0 * z, g_acc + o.0 * z),
+    );
+    let norms = CurveGroup::normalize_batch(&[input, output]);
+    (Input(norms[0]), Output(norms[1]))
 }
 
 #[cfg(test)]

--- a/src/utils/common.rs
+++ b/src/utils/common.rs
@@ -353,6 +353,10 @@ where
 ///
 /// The `dom_sep` byte allows callers to domain-separate different schemes.
 ///
+/// The ordering of `ios` matters: the delinearization scalars are derived from
+/// the hash of the pairs in the given order, so the prover and verifier must
+/// use the same ordering to obtain the same merged pair.
+///
 /// - N=0: returns the identity point for both input and output.
 /// - N=1: returns the pair as-is, no hashing or scalar multiplications.
 /// - N>1: derives per-pair 128-bit scalars (2^{-128} Schwartz-Zippel soundness)

--- a/src/utils/common.rs
+++ b/src/utils/common.rs
@@ -344,65 +344,20 @@ where
     }
 }
 
-/// Delinearization scalars for multi-input DLEQ proofs.
+/// Delinearize multiple input-output pairs into a single pair.
 ///
-/// Derives per-input scalars using the technique from Privacy Pass / dleq_vrf.
-/// Each scalar is 128-bit, providing 2^{-128} Schwartz-Zippel soundness.
-///
-/// The `dom_sep` byte allows callers to domain-separate different schemes.
-///
-/// Seed: `H(suite_id || dom_sep || N || encode(H_0) || encode(Gamma_0) || ... || ad || 0x00)`
-pub fn delinearization_scalars<S: Suite>(
-    dom_sep: u8,
-    ios: &[(Input<S>, Output<S>)],
-    ad: &[u8],
-) -> Vec<ScalarField<S>> {
-    const DOM_SEP_BACK: u8 = 0x00;
-
-    let mut hasher = S::Hasher::new();
-    hasher.update(S::SUITE_ID);
-    hasher.update([dom_sep]);
-
-    let mut pt_buf = Vec::with_capacity(S::Codec::POINT_ENCODED_LEN);
-
-    let n = ios.len() as u32;
-    hasher.update(n.to_le_bytes());
-
-    for (input, output) in ios {
-        pt_buf.clear();
-        S::Codec::point_encode_into(&input.0, &mut pt_buf);
-        hasher.update(&pt_buf);
-        pt_buf.clear();
-        S::Codec::point_encode_into(&output.0, &mut pt_buf);
-        hasher.update(&pt_buf);
-    }
-
-    hasher.update(ad);
-    hasher.update([DOM_SEP_BACK]);
-    let seed = hasher.finalize();
-
-    // For each i: z_i = H(seed || i_as_u32_le) truncated to 128 bits
-    (0..n)
-        .map(|i| {
-            let h = S::Hasher::new()
-                .chain_update(&seed)
-                .chain_update(i.to_le_bytes())
-                .finalize();
-            ScalarField::<S>::from_le_bytes_mod_order(&h[..16])
-        })
-        .collect()
-}
-
-/// Delinearize and merge multiple input-output pairs into a single pair.
-///
+/// Derives 128-bit delinearization scalars (Privacy Pass / dleq_vrf technique)
+/// and folds the ios into `(sum(z_i * input_i), sum(z_i * output_i))`.
 /// The resulting `(Input, Output)` can be passed directly to a scheme's
 /// `prove` / `verify` to obtain or check a single proof covering all pairs.
 ///
+/// The `dom_sep` byte allows callers to domain-separate different schemes.
+///
 /// - N=0: returns the identity point for both input and output.
-/// - N=1: returns the pair as-is, no delinearization.
-/// - N>1: derives 128-bit delinearization scalars and returns
-///   `(sum(z_i * H_i), sum(z_i * Gamma_i))`.
-pub fn merge<S: Suite>(
+/// - N=1: returns the pair as-is, no hashing or scalar multiplications.
+/// - N>1: derives per-pair 128-bit scalars (2^{-128} Schwartz-Zippel soundness)
+///   and returns their linear combination.
+pub fn delinearize<S: Suite>(
     dom_sep: u8,
     ios: &[(Input<S>, Output<S>)],
     ad: &[u8],
@@ -417,10 +372,39 @@ pub fn merge<S: Suite>(
         return (ios[0].0, ios[0].1);
     }
 
-    let zs = delinearization_scalars::<S>(dom_sep, ios, ad);
-    let (input, output) = ios.iter().zip(zs.iter()).fold(
+    // Seed: H(suite_id || dom_sep || N || encode(H_0) || encode(Gamma_0) || ... || ad || 0x00)
+    const DOM_SEP_BACK: u8 = 0x00;
+    let n = ios.len() as u32;
+
+    let mut hasher = S::Hasher::new();
+    hasher.update(S::SUITE_ID);
+    hasher.update([dom_sep]);
+    hasher.update(n.to_le_bytes());
+
+    let mut pt_buf = Vec::with_capacity(S::Codec::POINT_ENCODED_LEN);
+    for (input, output) in ios {
+        pt_buf.clear();
+        S::Codec::point_encode_into(&input.0, &mut pt_buf);
+        hasher.update(&pt_buf);
+        pt_buf.clear();
+        S::Codec::point_encode_into(&output.0, &mut pt_buf);
+        hasher.update(&pt_buf);
+    }
+    hasher.update(ad);
+    hasher.update([DOM_SEP_BACK]);
+    let seed = hasher.finalize();
+
+    // Derive z_i = H(seed || i_le) truncated to 128 bits, accumulate on the fly.
+    let (input, output) = ios.iter().enumerate().fold(
         (zero.into_group(), zero.into_group()),
-        |(h_acc, g_acc), ((i, o), z)| (h_acc + i.0 * z, g_acc + o.0 * z),
+        |(h_acc, g_acc), (i, (inp, out))| {
+            let h = S::Hasher::new()
+                .chain_update(&seed)
+                .chain_update((i as u32).to_le_bytes())
+                .finalize();
+            let z = ScalarField::<S>::from_le_bytes_mod_order(&h[..16]);
+            (h_acc + inp.0 * z, g_acc + out.0 * z)
+        },
     );
     let norms = CurveGroup::normalize_batch(&[input, output]);
     (Input(norms[0]), Output(norms[1]))

--- a/src/utils/common.rs
+++ b/src/utils/common.rs
@@ -344,6 +344,58 @@ where
     }
 }
 
+/// Delinearization scalars for multi-input DLEQ proofs.
+///
+/// Derives per-input scalars using the technique from Privacy Pass / dleq_vrf.
+/// Each scalar is 128-bit, providing 2^{-128} Schwartz-Zippel soundness.
+///
+/// Uses domain separator `0x04` (unused by TAI=0x01, challenge=0x02, point_to_hash=0x03).
+pub fn delinearization_scalars<S: Suite>(
+    pk: &AffinePoint<S>,
+    ios: &[(Input<S>, Output<S>)],
+    ad: &[u8],
+) -> Vec<ScalarField<S>> {
+    const DOM_SEP_FRONT: u8 = 0x04;
+    const DOM_SEP_BACK: u8 = 0x00;
+
+    let n = ios.len() as u32;
+
+    // Seed: H(suite_id || 0x04 || encode(pk) || N || encode(H_0) || encode(Gamma_0) || ... || ad || 0x00)
+    let mut hasher = S::Hasher::new();
+    hasher.update(S::SUITE_ID);
+    hasher.update([DOM_SEP_FRONT]);
+
+    let mut pt_buf = Vec::with_capacity(S::Codec::POINT_ENCODED_LEN);
+    S::Codec::point_encode_into(pk, &mut pt_buf);
+    hasher.update(&pt_buf);
+
+    hasher.update(n.to_le_bytes());
+
+    for (input, output) in ios {
+        pt_buf.clear();
+        S::Codec::point_encode_into(&input.0, &mut pt_buf);
+        hasher.update(&pt_buf);
+        pt_buf.clear();
+        S::Codec::point_encode_into(&output.0, &mut pt_buf);
+        hasher.update(&pt_buf);
+    }
+
+    hasher.update(ad);
+    hasher.update([DOM_SEP_BACK]);
+    let seed = hasher.finalize();
+
+    // For each i: z_i = H(seed || i_as_u32_le) truncated to 128 bits
+    (0..n)
+        .map(|i| {
+            let h = S::Hasher::new()
+                .chain_update(&seed)
+                .chain_update(i.to_le_bytes())
+                .finalize();
+            ScalarField::<S>::from_le_bytes_mod_order(&h[..16])
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
- Add `utils::delinearize` to fold N input-output pairs into a single `(Input, Output)` using 128-bit delinearization scalars (Privacy Pass technique, 2^{-128} Schwartz-Zippel soundness).
- The merged pair is passed to the standard `prove`/`verify` -- no new trait methods needed. 
- Works with IETF, Pedersen, and Ring VRF. N=1 is byte-identical to standard prove. N=0 reduces to a Schnorr signature over the additional data.

### Usage Example

  ```rust
  use ark_vrf::suites::bandersnatch::*;
  use ark_vrf::ietf::{Prover, Verifier};
  use ark_vrf::utils;

  let secret = Secret::from_seed(b"seed");
  let public = secret.public();

  // Build input-output pairs
  let mut ios: Vec<(Input, Output)> = (0..3)
      .map(|i| {
          let input = Input::new(&[i + 1]).unwrap();
          (input, secret.output(input))
      })
      .collect();
  // Include (G, pk) to bind the transcript to this pk
  ios.push((Input(AffinePoint::generator()), Output(public.0)));

  // Delinearize into a single pair, then prove/verify as usual
  let (input, output) = utils::delinearize::<BandersnatchSha512Ell2>(&ios, b"ad");

  let proof = secret.prove(input, output, ad);
  assert!(public.verify(input, output, ad, &proof).is_ok());
```

  Ring VRF works the same way -- delinearize first, then pass the merged pair to ring::Prover::prove / ring::Verifier::verify.

cc @ggwpez
