### PR TITLE
Introduce RingContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - Unreleased
+
+### Added
+
+- `RingVerifierParams` struct for lightweight verifier-side ring proof parameter
+  caching. Contains only the PIOP parameters needed for verification, without
+  the KZG SRS required by provers.
+
+### Removed
+
+- `RingProofParams::verifier_no_context` method, superseded by
+  `RingVerifierParams::from_ring_size`.
+
 ## [0.4.0] - 2026-04-02
 
 This release follows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `RingVerifierParams` struct for lightweight verifier-side ring proof parameter
-  caching. Contains only the PIOP parameters needed for verification, without
-  the KZG SRS required by provers.
+- `RingContext` struct for lightweight ring proof parameter caching.
+  Contains only the PIOP parameters needed for prover/verifier instance
+  construction, without the KZG SRS required for key construction.
+
+### Changed
+
+- `RingProofParams` renamed to `RingSetup`.
 
 ### Removed
 
 - `RingProofParams::verifier_no_context` method, superseded by
-  `RingVerifierParams::from_ring_size`.
+  `RingContext::new`.
 
 ## [0.4.0] - 2026-04-02
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ use ark_vrf::ring::Verifier;
 let verifier_key = ring_setup.verifier_key(&ring).unwrap();
 
 // Create a verifier instance
-let ring_ctx = RingContext::new(RING_SIZE);
+let ring_ctx = ring_setup.ring_context();
 let verifier = ring_ctx.ring_verifier(verifier_key);
 
 // Verify the proof - this confirms that:

--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ let mut ring = (0..RING_SIZE)
 ring[prover_key_index] = public.0;
 
 // Any key can be replaced with the padding point
-ring[0] = RingProofParams::padding_point();
+ring[0] = RingSetup::padding_point();
 
 // Create parameters for the ring proof system.
 // These parameters are reusable across multiple proofs.
-let params = RingProofParams::from_seed(RING_SIZE, [0x42; 32]);
+let ring_setup = RingSetup::from_seed(RING_SIZE, [0x42; 32]);
 ```
 
 _Prove_
@@ -186,10 +186,13 @@ _Prove_
 use ark_vrf::ring::Prover;
 
 // Create a prover key specific to this ring
-let prover_key = params.prover_key(&ring).unwrap();
+let prover_key = ring_setup.prover_key(&ring).unwrap();
+
+// Create a lightweight ring context for prover/verifier construction
+let ring_ctx = ring_setup.ring_context();
 
 // Create a prover instance for the specific position in the ring
-let prover = params.prover(prover_key, prover_key_index);
+let prover = ring_ctx.ring_prover(prover_key, prover_key_index);
 
 let io = secret.vrf_io(input);
 
@@ -204,10 +207,11 @@ _Verify_
 use ark_vrf::ring::Verifier;
 
 // Create a verifier key for this ring
-let verifier_key = params.verifier_key(&ring).unwrap();
+let verifier_key = ring_setup.verifier_key(&ring).unwrap();
 
 // Create a verifier instance
-let verifier = params.verifier(verifier_key);
+let ring_ctx = RingContext::new(RING_SIZE);
+let verifier = ring_ctx.ring_verifier(verifier_key);
 
 // Verify the proof - this confirms that:
 // 1. The proof was created by someone who knows a secret key in the ring
@@ -219,11 +223,11 @@ let result = Public::verify(io, b"aux data", &proof, &verifier);
 _Verifier key from commitment_
 ```rust,ignore
 // For efficiency, a commitment to the ring can be shared
-let ring_commitment = params.verifier_key(&ring).unwrap().commitment();
+let ring_commitment = ring_setup.verifier_key(&ring).unwrap().commitment();
 
 // A verifier can reconstruct the verifier key from just the commitment
 // without needing the full ring of public keys
-let verifier_key = params.verifier_key_from_commitment(ring_commitment);
+let verifier_key = ring_setup.verifier_key_from_commitment(ring_commitment);
 ```
 
 ## Features

--- a/benches/SUMMARY.md
+++ b/benches/SUMMARY.md
@@ -1,7 +1,7 @@
 # Benchmark Baseline
 
 Suite: Bandersnatch SHA-512 ELL2 (Twisted Edwards on BLS12-381)
-Date: 2026-04-02
+Date: 2026-04-09
 Features: `bandersnatch`, `ring`, `asm` (no `parallel`)
 Criterion: `--quick` mode
 
@@ -9,80 +9,81 @@ Criterion: `--quick` mode
 
 - CPU: AMD Ryzen Threadripper 3970X 32-Core (64 threads @ 3.7 GHz base, 4.5 GHz boost)
 - RAM: 64 GB DDR4
-- OS: Arch Linux, kernel 6.19.10
-- Rust: 1.93.0 (254b59607 2026-01-19)
+- OS: Arch Linux, kernel 6.19.11
+- Rust: 1.94.1 (e408947bf 2026-03-25)
 
 ## Common Operations (`common.rs`)
 
 | Benchmark                    |     Time |
 |:-----------------------------|---------:|
-| vrf_output                   | 77.2 us  |
-| data_to_point_tai            | 20.9 us  |
-| data_to_point_ell2           | 68.5 us  |
-| point_to_hash                | 623 ns   |
+| vrf_output                   | 83.1 us  |
+| data_to_point_tai            | 20.7 us  |
+| data_to_point_ell2           | 67.3 us  |
+| point_to_hash                | 600 ns   |
 | challenge                    | 1.10 us  |
-| nonce_rfc_8032               | 2.04 us  |
+| nonce_rfc_8032               | 2.02 us  |
 
 ## Tiny VRF Operations (`tiny.rs`)
 
 | Benchmark              |     Time |
 |:-----------------------|---------:|
-| tiny_prove             | 184.2 us |
-| tiny_verify            | 187.6 us |
+| tiny_prove             | 191.3 us |
+| tiny_verify            | 197.5 us |
 
 ## Pedersen VRF Operations (`pedersen.rs`)
 
 | Benchmark              |     Time |
 |:-----------------------|---------:|
-| pedersen_prove         | 382.8 us |
-| pedersen_verify        | 219.8 us |
+| pedersen_prove         | 385.2 us |
+| pedersen_verify        | 233.2 us |
 
 ### Batch Verification
 
 | Benchmark            | n=1      | n=2      | n=4      | n=8      | n=16     | n=32     | n=64     | n=128    | n=256    |
 |:---------------------|----------|----------|----------|----------|----------|----------|----------|----------|----------|
-| batch_prepare        | 1.23 us  | 2.43 us  | 4.78 us  | 9.49 us  | 19.1 us  | 36.0 us  | 72.0 us  | 143.4 us | 304.2 us |
-| batch_verify         | 503.4 us | 595.0 us | 719.9 us | 1.75 ms  | 2.12 ms  | 3.77 ms  | 5.74 ms  | 7.94 ms  | 15.2 ms  |
+| batch_prepare        | 1.21 us  | 2.40 us  | 4.83 us  | 9.55 us  | 19.2 us  | 38.0 us  | 76.1 us  | 155.9 us | 303.6 us |
+| batch_verify         | 515.9 us | 604.6 us | 777.5 us | 1.77 ms  | 2.15 ms  | 3.65 ms  | 6.18 ms  | 8.46 ms  | 15.4 ms  |
 
 ## Thin VRF Operations (`thin.rs`)
 
 | Benchmark              |     Time |
 |:-----------------------|---------:|
-| thin_prove             | 193.2 us |
-| thin_verify            | 197.9 us |
+| thin_prove             | 188.4 us |
+| thin_verify            | 190.9 us |
 
 ### Batch Verification
 
 | Benchmark            | n=1      | n=2      | n=4      | n=8      | n=16     | n=32     | n=64     | n=128    | n=256    |
 |:---------------------|----------|----------|----------|----------|----------|----------|----------|----------|----------|
-| batch_prepare        | 1.88 us  | 3.77 us  | 7.54 us  | 15.0 us  | 28.1 us  | 61.2 us  | 123.3 us | 246.6 us | 495.8 us |
-| batch_verify         | 474.9 us | 546.0 us | 703.1 us | 1.67 ms  | 2.01 ms  | 3.40 ms  | 5.88 ms  | 7.88 ms  | 14.0 ms  |
+| batch_prepare        | 1.90 us  | 3.83 us  | 7.59 us  | 15.3 us  | 30.6 us  | 61.6 us  | 123.5 us | 248.6 us | 513.3 us |
+| batch_verify         | 489.0 us | 567.0 us | 717.6 us | 1.74 ms  | 2.04 ms  | 3.47 ms  | 5.95 ms  | 7.88 ms  | 14.4 ms  |
 
 ## Ring VRF Operations (`ring.rs`)
 
 | Benchmark              | n=255     | n=1023    | n=2047    |
 |:-----------------------|----------:|----------:|----------:|
-| ring_params_setup      | 0.80 ms   | 3.70 ms   | 9.08 ms   |
-| ring_prover_key        | 42.2 ms   | 129.5 ms  | 235.0 ms  |
-| ring_verifier_key      | 44.7 ms   | 137.7 ms  | 251.3 ms  |
-| ring_prove             | 150.6 ms  | 481.6 ms  | 884.9 ms  |
-| ring_verify            | 3.30 ms   | 3.28 ms   | 3.23 ms   |
-| ring_verifier_from_key | 257.2 us  | 277.0 us  | 315.2 us  |
-| ring_vk_from_commitment| 74.7 ns   | 74.6 ns   | 75.3 ns   |
-| ring_vk_builder_create | 307.7 ms  | 1.459 s   | 3.139 s   |
-| ring_vk_builder_append | 15.3 ms   | 45.1 ms   | 81.9 ms   |
-| ring_vk_builder_finalize | 111.5 ns | 101.3 ns  | 112.3 ns  |
+| ring_params_setup      | 0.85 ms   | 3.67 ms   | 8.38 ms   |
+| ring_context_setup     | 0.85 ms   | 3.64 ms   | 8.35 ms   |
+| ring_prover_key        | 44.9 ms   | 129.6 ms  | 250.8 ms  |
+| ring_verifier_key      | 44.4 ms   | 138.1 ms  | 251.5 ms  |
+| ring_prove             | 149.9 ms  | 480.9 ms  | 810.1 ms  |
+| ring_verify            | 3.30 ms   | 3.27 ms   | 3.03 ms   |
+| ring_verifier_from_key | 252.9 us  | 273.3 us  | 284.0 us  |
+| ring_vk_from_commitment| 73.9 ns   | 76.3 ns   | 71.8 ns   |
+| ring_vk_builder_create | 319.2 ms  | 1.438 s   | 3.152 s   |
+| ring_vk_builder_append | 15.2 ms   | 48.4 ms   | 80.4 ms   |
+| ring_vk_builder_finalize | 99.6 ns | 108.9 ns  | 104.7 ns  |
 
 ### Batch Verification (ring size = 1023)
 
 | Benchmark          | n=1      | n=2      | n=4      | n=8      | n=16     | n=32     | n=64     | n=128    | n=256    |
 |:-------------------|----------|----------|----------|----------|----------|----------|----------|----------|----------|
-| batch_verifier_new | 269 us   | -        | -        | -        | -        | -        | -        | -        | -        |
-| batch_push         | 49.9 us  | 102.9 us | 222.3 us | 408.5 us | 887.1 us | 1.78 ms  | 3.52 ms  | 6.63 ms  | 14.4 ms  |
-| batch_prepare_seq  | 47.4 us  | 88.7 us  | 178.5 us | 395.7 us | 801.7 us | 1.62 ms  | 3.26 ms  | 6.12 ms  | 12.3 ms  |
-| batch_prepare_par  | 44.1 us  | 74.7 us  | 108.6 us | 156.1 us | 219.4 us | 248.7 us | 262.4 us | 497.7 us | 798.3 us |
-| batch_push_prepared| 5.7 us   | 9.8 us   | 22.1 us  | 39.5 us  | 72.9 us  | 147.6 us | 263.5 us | 523.6 us | 1.07 ms  |
-| batch_verify       | 3.49 ms  | 4.31 ms  | 5.86 ms  | 8.61 ms  | 12.7 ms  | 20.9 ms  | 31.1 ms  | 52.3 ms  | 92.9 ms  |
+| batch_verifier_new | 273 us   | -        | -        | -        | -        | -        | -        | -        | -        |
+| batch_push         | 50.8 us  | 97.7 us  | 214.6 us | 426.5 us | 888.5 us | 1.77 ms  | 3.52 ms  | 7.04 ms  | 13.2 ms  |
+| batch_prepare_seq  | 41.3 us  | 89.4 us  | 179.7 us | 388.0 us | 803.9 us | 1.67 ms  | 3.26 ms  | 6.65 ms  | 13.5 ms  |
+| batch_prepare_par  | 49.1 us  | 73.6 us  | 115.2 us | 154.6 us | 212.6 us | 236.3 us | 225.7 us | 468.4 us | 768.2 us |
+| batch_push_prepared| 5.3 us   | 9.9 us   | 19.8 us  | 38.8 us  | 74.0 us  | 145.0 us | 271.9 us | 526.7 us | 1.07 ms  |
+| batch_verify       | 3.48 ms  | 4.38 ms  | 5.98 ms  | 8.63 ms  | 12.7 ms  | 20.8 ms  | 32.3 ms  | 57.5 ms  | 100.0 ms |
 
 ## Straus MSM (`straus.rs`)
 
@@ -91,10 +92,10 @@ The table shows times for the bandersnatch suite.
 
 | n\w | w=1       | w=2       | w=3       | w=4       |
 |----:|----------:|----------:|----------:|----------:|
-|   2 | 115.8 us  | 87.9 us   | 94.6 us   | 160.3 us  |
-|   3 | 117.6 us  | 105.4 us  | 264.6 us  | 1.64 ms   |
-|   4 | 121.1 us  | 178.6 us  | 1.62 ms   | 24.7 ms   |
-|   5 | 120.3 us  | 447.9 us  | 11.8 ms   | 537.0 ms  |
+|   2 | 118.4 us  | 90.5 us   | 98.0 us   | 161.8 us  |
+|   3 | 121.5 us  | 107.4 us  | 270.3 us  | 1.65 ms   |
+|   4 | 125.5 us  | 181.6 us  | 1.66 ms   | 25.1 ms   |
+|   5 | 130.6 us  | 481.7 us  | 12.5 ms   | 534.7 ms  |
 
 Table size is (2^w)^n, so the cost grows combinatorially in w for a given n.
 Optimal window size is w=2 for n=2 and w=1 for n>=3.
@@ -103,52 +104,55 @@ Optimal window size is w=2 for n=2 and w=1 for n>=3.
 
 ### Ring Operations
 
-- `ring_verify` is roughly constant across ring sizes (~3.3 ms) since verification
+- `ring_verify` is roughly constant across ring sizes (~3.2 ms) since verification
   cost depends on the PIOP domain size, which stays the same for all three sizes tested
   (they all round up to the same power-of-two domain).
-- `ring_prove` scales linearly with ring size: 151 ms at n=255, 482 ms at n=1023,
-  885 ms at n=2047.
-- `ring_vk_builder_create` is the most expensive operation (up to 3.1 s at n=2047).
+- `ring_prove` scales linearly with ring size: 150 ms at n=255, 481 ms at n=1023,
+  810 ms at n=2047.
+- `ring_vk_builder_create` is the most expensive operation (up to 3.2 s at n=2047).
   This is the Lagrangian SRS computation.
 - `ring_vk_builder_finalize` and `ring_vk_from_commitment` are essentially free
-  (sub-112 ns).
+  (sub-109 ns).
+- `ring_context_setup` and `ring_params_setup` have identical cost (~0.85 ms at n=255,
+  ~3.6 ms at n=1023, ~8.4 ms at n=2047), confirming that `RingContext` construction
+  is dominated by PIOP domain setup with no SRS overhead.
 
 ### Batch Verification vs Simple Verification
 
 Simple verification cost for n proofs (ring size 1023):
-`ring_verifier_from_key` (277 us) + n * `ring_verify` (3.28 ms).
+`ring_verifier_from_key` (273 us) + n * `ring_verify` (3.27 ms).
 
 Batch verification combines multiple pairing checks into a single multi-pairing
 (ring proof) and multiple Pedersen verifications into a single (5N+2)-point MSM.
 
-The `prepare` step (~47 us/proof) computes only the Pedersen challenge hash and
+The `prepare` step (~41 us/proof) computes only the Pedersen challenge hash and
 packages data for deferred verification -- no scalar multiplications. The Pedersen
 verification is deferred to `verify`, where it runs as a single batched MSM using
 random linear combination with independent random scalars per equation.
 
 The `verify` step includes both the ring batch multi-pairing and the Pedersen
-batch MSM. A linear fit gives ~3.1 ms base + ~0.35 ms per additional proof.
-The ring multi-pairing marginal cost is ~0.32 ms/proof; the Pedersen MSM adds
+batch MSM. A linear fit gives ~3.1 ms base + ~0.38 ms per additional proof.
+The ring multi-pairing marginal cost is ~0.35 ms/proof; the Pedersen MSM adds
 ~0.03 ms/proof amortized.
 
-Sequential marginal cost per proof: ~0.05 ms (prepare) + ~0.35 ms (verify) = ~0.40 ms,
-or ~8.2x cheaper than simple verification (3.28 ms). With parallel prepare, the
-per-proof prepare cost drops to ~3 us at n=256, giving ~0.35 ms marginal, or ~9.4x
+Sequential marginal cost per proof: ~0.05 ms (prepare) + ~0.38 ms (verify) = ~0.43 ms,
+or ~7.6x cheaper than simple verification (3.27 ms). With parallel prepare, the
+per-proof prepare cost drops to ~3 us at n=256, giving ~0.38 ms marginal, or ~8.6x
 cheaper.
 
 Estimated total wall times and speedups:
 
 | n   | Simple      | Batch seq   | Batch par   | Speedup (seq) | Speedup (par) |
 |----:|------------:|------------:|------------:|--------------:|--------------:|
-|   1 |    3.56 ms  |    3.54 ms  |    3.53 ms  |         1.01x |         1.01x |
-|   2 |    6.84 ms  |    4.40 ms  |    4.39 ms  |         1.55x |         1.56x |
-|   4 |   13.39 ms  |    6.04 ms  |    5.97 ms  |         2.22x |         2.24x |
-|   8 |   26.50 ms  |    9.01 ms  |    8.77 ms  |         2.94x |         3.02x |
-|  16 |   52.73 ms  |   13.50 ms  |   12.92 ms  |         3.91x |         4.08x |
-|  32 |  105.18 ms  |   22.52 ms  |   21.15 ms  |         4.67x |         4.97x |
-|  64 |  210.07 ms  |   34.37 ms  |   31.37 ms  |         6.11x |         6.70x |
-| 128 |  419.87 ms  |   58.42 ms  |   52.80 ms  |         7.19x |         7.95x |
-| 256 |  839.45 ms  |  105.20 ms  |   93.73 ms  |         7.98x |         8.96x |
+|   1 |    3.54 ms  |    3.52 ms  |    3.53 ms  |         1.01x |         1.00x |
+|   2 |    6.81 ms  |    4.47 ms  |    4.45 ms  |         1.52x |         1.53x |
+|   4 |   13.35 ms  |    6.16 ms  |    6.10 ms  |         2.17x |         2.19x |
+|   8 |   26.43 ms  |    9.02 ms  |    8.78 ms  |         2.93x |         3.01x |
+|  16 |   52.59 ms  |   13.52 ms  |   12.93 ms  |         3.89x |         4.07x |
+|  32 |  104.91 ms  |   22.47 ms  |   21.04 ms  |         4.67x |         4.99x |
+|  64 |  209.55 ms  |   36.77 ms  |   32.52 ms  |         5.70x |         6.44x |
+| 128 |  418.83 ms  |   64.15 ms  |   57.96 ms  |         6.53x |         7.23x |
+| 256 |  837.39 ms  |  113.50 ms  |  100.77 ms  |         7.38x |         8.31x |
 
 ### Batch Verify Scaling
 
@@ -156,17 +160,17 @@ The `batch_verify` step scales sublinearly in the number of proofs:
 
 | n   | batch_verify | per-proof |
 |----:|-----------:|----------:|
-|   1 |    3.49 ms |  3.49 ms  |
-|   2 |    4.31 ms |  2.16 ms  |
-|   4 |    5.86 ms |  1.47 ms  |
-|   8 |    8.61 ms |  1.08 ms  |
+|   1 |    3.48 ms |  3.48 ms  |
+|   2 |    4.38 ms |  2.19 ms  |
+|   4 |    5.98 ms |  1.50 ms  |
+|   8 |    8.63 ms |  1.08 ms  |
 |  16 |   12.7 ms  |  0.79 ms  |
-|  32 |   20.9 ms  |  0.65 ms  |
-|  64 |   31.1 ms  |  0.49 ms  |
-| 128 |   52.3 ms  |  0.41 ms  |
-| 256 |   92.9 ms  |  0.36 ms  |
+|  32 |   20.8 ms  |  0.65 ms  |
+|  64 |   32.3 ms  |  0.50 ms  |
+| 128 |   57.5 ms  |  0.45 ms  |
+| 256 |  100.0 ms  |  0.39 ms  |
 
-Amortized cost per proof drops from 3.49 ms (n=1) to 0.36 ms (n=256), roughly 9.7x.
+Amortized cost per proof drops from 3.48 ms (n=1) to 0.39 ms (n=256), roughly 8.9x.
 Two factors contribute: the fixed-cost ring multi-pairing base (~3.5 ms) amortized
 across all proofs, and the MSM itself which scales as O(n / log n) via
 Pippenger/bucket methods rather than O(n).

--- a/benches/ring.rs
+++ b/benches/ring.rs
@@ -12,15 +12,15 @@ use rayon::prelude::*;
 
 const RING_SIZES: [usize; 3] = [255, 1023, 2047];
 
-struct RingSetup<S: RingSuite> {
+struct BenchSetup<S: RingSuite> {
     secret: Secret<S>,
     io: VrfIo<S>,
     ring: Vec<AffinePoint<S>>,
     prover_idx: usize,
-    params: ring::RingProofParams<S>,
+    ring_setup: ring::RingSetup<S>,
 }
 
-fn make_ring_setup<S: RingSuite>(ring_size: usize) -> RingSetup<S> {
+fn make_ring_setup<S: RingSuite>(ring_size: usize) -> BenchSetup<S> {
     let mut rng = ark_std::test_rng();
     let secret = Secret::<S>::from_seed([0; 32]);
     let public = secret.public();
@@ -33,14 +33,14 @@ fn make_ring_setup<S: RingSuite>(ring_size: usize) -> RingSetup<S> {
         .collect();
     ring[prover_idx] = public.0;
 
-    let params = ring::RingProofParams::<S>::from_rand(ring_size, &mut rng);
+    let ring_setup = ring::RingSetup::<S>::from_rand(ring_size, &mut rng);
 
-    RingSetup {
+    BenchSetup {
         secret,
         io,
         ring,
         prover_idx,
-        params,
+        ring_setup,
     }
 }
 
@@ -53,28 +53,40 @@ fn ring_benches<S: BenchInfo + RingSuite>(c: &mut Criterion) {
             .sample_size(10)
             .bench_function(id.clone(), |b| {
                 b.iter(|| {
-                    ring::RingProofParams::<S>::from_pcs_params(
+                    ring::RingSetup::<S>::from_pcs_params(
                         black_box(n),
-                        setup.params.pcs.clone(),
+                        setup.ring_setup.pcs_params.clone(),
                     )
                     .unwrap()
                 });
             });
 
+        c.benchmark_group(format!("{}/ring_context_setup", S::SUITE_NAME))
+            .sample_size(10)
+            .bench_function(id.clone(), |b| {
+                b.iter(|| ring::RingContext::<S>::new(black_box(n)));
+            });
+
         c.benchmark_group(format!("{}/ring_prover_key", S::SUITE_NAME))
             .sample_size(10)
             .bench_function(id.clone(), |b| {
-                b.iter(|| setup.params.prover_key(black_box(&setup.ring)).unwrap());
+                b.iter(|| setup.ring_setup.prover_key(black_box(&setup.ring)).unwrap());
             });
 
         c.benchmark_group(format!("{}/ring_verifier_key", S::SUITE_NAME))
             .sample_size(10)
             .bench_function(id.clone(), |b| {
-                b.iter(|| setup.params.verifier_key(black_box(&setup.ring)).unwrap());
+                b.iter(|| {
+                    setup
+                        .ring_setup
+                        .verifier_key(black_box(&setup.ring))
+                        .unwrap()
+                });
             });
 
-        let prover_key = setup.params.prover_key(&setup.ring).unwrap();
-        let prover = setup.params.prover(prover_key, setup.prover_idx);
+        let ring_ctx = setup.ring_setup.ring_context();
+        let prover_key = setup.ring_setup.prover_key(&setup.ring).unwrap();
+        let prover = ring_ctx.ring_prover(prover_key, setup.prover_idx);
 
         c.benchmark_group(format!("{}/ring_prove", S::SUITE_NAME))
             .sample_size(10)
@@ -83,9 +95,9 @@ fn ring_benches<S: BenchInfo + RingSuite>(c: &mut Criterion) {
             });
 
         let proof = setup.secret.prove(setup.io, b"ad", &prover);
-        let verifier_key = setup.params.verifier_key(&setup.ring).unwrap();
+        let verifier_key = setup.ring_setup.verifier_key(&setup.ring).unwrap();
         let commitment = verifier_key.commitment();
-        let verifier = setup.params.verifier(verifier_key.clone());
+        let verifier = ring_ctx.ring_verifier(verifier_key.clone());
 
         c.benchmark_group(format!("{}/ring_verify", S::SUITE_NAME))
             .sample_size(10)
@@ -104,7 +116,7 @@ fn ring_benches<S: BenchInfo + RingSuite>(c: &mut Criterion) {
         c.benchmark_group(format!("{}/ring_verifier_from_key", S::SUITE_NAME))
             .sample_size(10)
             .bench_function(id.clone(), |b| {
-                b.iter(|| setup.params.verifier(black_box(verifier_key.clone())));
+                b.iter(|| ring_ctx.ring_verifier(black_box(verifier_key.clone())));
             });
 
         c.benchmark_group(format!("{}/ring_vk_from_commitment", S::SUITE_NAME))
@@ -112,7 +124,7 @@ fn ring_benches<S: BenchInfo + RingSuite>(c: &mut Criterion) {
             .bench_function(id.clone(), |b| {
                 b.iter(|| {
                     setup
-                        .params
+                        .ring_setup
                         .verifier_key_from_commitment(black_box(commitment.clone()))
                 });
             });
@@ -120,10 +132,10 @@ fn ring_benches<S: BenchInfo + RingSuite>(c: &mut Criterion) {
         c.benchmark_group(format!("{}/ring_vk_builder_create", S::SUITE_NAME))
             .sample_size(10)
             .bench_function(id.clone(), |b| {
-                b.iter(|| setup.params.verifier_key_builder());
+                b.iter(|| setup.ring_setup.verifier_key_builder());
             });
 
-        let (mut builder, builder_pcs_params) = setup.params.verifier_key_builder();
+        let (mut builder, builder_pcs_params) = setup.ring_setup.verifier_key_builder();
 
         c.benchmark_group(format!("{}/ring_vk_builder_append", S::SUITE_NAME))
             .sample_size(10)
@@ -157,8 +169,9 @@ struct BatchItem<S: RingSuite> {
 fn batch_benches<S: BenchInfo + RingSuite>(c: &mut Criterion) {
     let setup = make_ring_setup::<S>(1023);
 
-    let prover_key = setup.params.prover_key(&setup.ring).unwrap();
-    let prover = setup.params.prover(prover_key, setup.prover_idx);
+    let ring_ctx = setup.ring_setup.ring_context();
+    let prover_key = setup.ring_setup.prover_key(&setup.ring).unwrap();
+    let prover = ring_ctx.ring_prover(prover_key, setup.prover_idx);
 
     let max_batch_size = BATCH_SIZES[BATCH_SIZES.len() - 1];
 
@@ -181,7 +194,7 @@ fn batch_benches<S: BenchInfo + RingSuite>(c: &mut Criterion) {
         })
         .collect();
 
-    let verifier_key = setup.params.verifier_key(&setup.ring).unwrap();
+    let verifier_key = setup.ring_setup.verifier_key(&setup.ring).unwrap();
 
     // batch_verifier_new: cost is independent of batch size, bench once.
     c.benchmark_group(format!("{}/batch_verifier_new", S::SUITE_NAME))
@@ -189,14 +202,14 @@ fn batch_benches<S: BenchInfo + RingSuite>(c: &mut Criterion) {
         .bench_function("batch_verifier_new", |b| {
             b.iter(|| {
                 let vk = verifier_key.clone();
-                let verifier = setup.params.verifier(vk);
+                let verifier = ring_ctx.ring_verifier(vk);
                 BatchVerifier::<S>::new(black_box(verifier))
             });
         });
 
     // A single BatchVerifier for prepare benchmarks (prepare takes &self).
     let vk = verifier_key.clone();
-    let verifier = setup.params.verifier(vk);
+    let verifier = ring_ctx.ring_verifier(vk);
     let batch_verifier = BatchVerifier::<S>::new(verifier);
 
     for &batch_size in BATCH_SIZES {
@@ -209,7 +222,7 @@ fn batch_benches<S: BenchInfo + RingSuite>(c: &mut Criterion) {
                 b.iter_batched(
                     || {
                         let vk = verifier_key.clone();
-                        let verifier = setup.params.verifier(vk);
+                        let verifier = ring_ctx.ring_verifier(vk);
                         BatchVerifier::<S>::new(verifier)
                     },
                     |mut bv| {
@@ -256,7 +269,7 @@ fn batch_benches<S: BenchInfo + RingSuite>(c: &mut Criterion) {
                             .map(|item| batch_verifier.prepare(item.io, &item.ad, &item.proof))
                             .collect::<Vec<_>>();
                         let vk = verifier_key.clone();
-                        let verifier = setup.params.verifier(vk);
+                        let verifier = ring_ctx.ring_verifier(vk);
                         let bv = BatchVerifier::<S>::new(verifier);
                         (bv, prepared)
                     },
@@ -272,7 +285,7 @@ fn batch_benches<S: BenchInfo + RingSuite>(c: &mut Criterion) {
         // batch_verify: verify a fully-populated batch.
         {
             let vk = verifier_key.clone();
-            let verifier = setup.params.verifier(vk);
+            let verifier = ring_ctx.ring_verifier(vk);
             let mut bv = BatchVerifier::<S>::new(verifier);
             for item in &batch_items[..batch_size] {
                 bv.push(item.io, &item.ad, &item.proof);

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -397,7 +397,6 @@ impl<S: RingSuite> RingProofParams<S> {
         self.verifier_params().verifier(verifier_key)
     }
 
-
     /// Get the padding point.
     ///
     /// This is a point of unknown dlog that can be used in place of any key during

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -224,6 +224,41 @@ impl<S: RingSuite> Verifier<S> for Public<S> {
     }
 }
 
+/// Lightweight verifier-side ring proof parameters.
+///
+/// Contains only the PIOP parameters needed for verification, without the KZG
+/// SRS required by provers. Construct once via [`RingVerifierParams::from_ring_size`]
+/// and reuse across verifications.
+#[derive(Clone)]
+pub struct RingVerifierParams<S: RingSuite> {
+    /// PIOP parameters.
+    pub piop: PiopParams<S>,
+}
+
+impl<S: RingSuite> RingVerifierParams<S> {
+    /// Construct verifier parameters for the given ring size.
+    pub fn from_ring_size(ring_size: usize) -> Self {
+        Self {
+            piop: piop_params::<S>(piop_domain_size::<S>(ring_size)),
+        }
+    }
+
+    /// The max ring size these parameters are able to handle.
+    #[inline(always)]
+    pub fn max_ring_size(&self) -> usize {
+        self.piop.keyset_part_size
+    }
+
+    /// Create a verifier instance from a verifier key.
+    pub fn verifier(&self, verifier_key: RingVerifierKey<S>) -> RingVerifier<S> {
+        RingVerifier::<S>::init(
+            verifier_key,
+            self.piop.clone(),
+            ring_proof::ArkTranscript::new(const { &S::SUITE_ID.to_bytes() }),
+        )
+    }
+}
+
 /// Ring proof parameters.
 ///
 /// Contains the cryptographic parameters needed for ring proof generation and verification:
@@ -347,29 +382,21 @@ impl<S: RingSuite> RingProofParams<S> {
         (builder, builder_pcs_params)
     }
 
-    /// Create a verifier instance from a verifier key.
-    pub fn verifier(&self, verifier_key: RingVerifierKey<S>) -> RingVerifier<S> {
-        RingVerifier::<S>::init(
-            verifier_key,
-            self.piop.clone(),
-            ring_proof::ArkTranscript::new(const { &S::SUITE_ID.to_bytes() }),
-        )
+    /// Extract lightweight verifier parameters.
+    ///
+    /// Returns a [`RingVerifierParams`] that can be stored and reused without
+    /// carrying the KZG SRS.
+    pub fn verifier_params(&self) -> RingVerifierParams<S> {
+        RingVerifierParams {
+            piop: self.piop.clone(),
+        }
     }
 
-    /// Create a verifier instance without requiring the full parameters.
-    ///
-    /// Computes necessary PIOP parameters on-the-fly from the ring size rather
-    /// than reusing the ones stored in `self`.
-    pub fn verifier_no_context(
-        verifier_key: RingVerifierKey<S>,
-        ring_size: usize,
-    ) -> RingVerifier<S> {
-        RingVerifier::<S>::init(
-            verifier_key,
-            piop_params::<S>(piop_domain_size::<S>(ring_size)),
-            ring_proof::ArkTranscript::new(const { &S::SUITE_ID.to_bytes() }),
-        )
+    /// Create a verifier instance from a verifier key.
+    pub fn verifier(&self, verifier_key: RingVerifierKey<S>) -> RingVerifier<S> {
+        self.verifier_params().verifier(verifier_key)
     }
+
 
     /// Get the padding point.
     ///
@@ -605,6 +632,8 @@ macro_rules! ring_suite_types {
         pub type PcsParams = $crate::ring::PcsParams<$suite>;
         #[allow(dead_code)]
         pub type PiopParams = $crate::ring::PiopParams<$suite>;
+        #[allow(dead_code)]
+        pub type RingVerifierParams = $crate::ring::RingVerifierParams<$suite>;
         #[allow(dead_code)]
         pub type RingProofParams = $crate::ring::RingProofParams<$suite>;
         #[allow(dead_code)]

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -292,7 +292,7 @@ impl<S: RingSuite> RingContext<S> {
 /// Contains the cryptographic parameters needed for ring proof key construction,
 /// proving and verification:
 /// - `pcs_params`: Polynomial Commitment Scheme parameters (KZG setup)
-/// - `piop_params`: Polynomial Interactive Oracle Proof parameters
+/// - `ring_ctx`: Ring context containing the PIOP parameters
 #[derive(Clone)]
 pub struct RingSetup<S: RingSuite> {
     /// PCS parameters.
@@ -1175,7 +1175,7 @@ pub(crate) mod testing {
         fn ring_setup() -> &'static RingSetup<Self>;
 
         #[allow(unused)]
-        fn load_context() -> RingSetup<Self> {
+        fn load_ring_setup() -> RingSetup<Self> {
             use ark_serialize::CanonicalDeserialize;
             use std::{fs::File, io::Read};
             let mut file = File::open(Self::SRS_FILE).unwrap();
@@ -1187,7 +1187,7 @@ pub(crate) mod testing {
         }
 
         #[allow(unused)]
-        fn write_context(ring_setup: &RingSetup<Self>) {
+        fn write_ring_setup(ring_setup: &RingSetup<Self>) {
             use ark_serialize::CanonicalSerialize;
             use std::{fs::File, io::Write};
             let mut file = File::create(Self::SRS_FILE).unwrap();

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -26,23 +26,24 @@
 //! ring[prover_key_index] = public.0;
 //!
 //! // Initialize ring parameters
-//! let params = RingProofParams::from_seed(RING_SIZE, [0x42; 32]);
+//! let ring_setup = RingSetup::from_seed(RING_SIZE, [0x42; 32]);
+//! let ring_ctx = ring_setup.ring_context();
 //!
 //! // Proving
-//! let prover_key = params.prover_key(&ring).unwrap();
-//! let prover = params.prover(prover_key, prover_key_index);
+//! let prover_key = ring_setup.prover_key(&ring).unwrap();
+//! let prover = ring_ctx.ring_prover(prover_key, prover_key_index);
 //! let io = secret.vrf_io(input);
 //! let proof = secret.prove(io, b"aux data", &prover);
 //!
 //! // Verification
 //! use ark_vrf::ring::Verifier;
-//! let verifier_key = params.verifier_key(&ring).unwrap();
-//! let verifier = params.verifier(verifier_key);
+//! let verifier_key = ring_setup.verifier_key(&ring).unwrap();
+//! let verifier = ring_ctx.ring_verifier(verifier_key);
 //! let result = Public::verify(io, b"aux data", &proof, &verifier);
 //!
 //! // Efficient verification with commitment
 //! let ring_commitment = verifier_key.commitment();
-//! let reconstructed_key = params.verifier_key_from_commitment(ring_commitment);
+//! let reconstructed_key = ring_setup.verifier_key_from_commitment(ring_commitment);
 //! ```
 
 use crate::*;
@@ -224,64 +225,91 @@ impl<S: RingSuite> Verifier<S> for Public<S> {
     }
 }
 
-/// Lightweight verifier-side ring proof parameters.
+/// Lightweight ring proof context.
 ///
-/// Contains only the PIOP parameters needed for verification, without the KZG
-/// SRS required by provers. Construct once via [`RingVerifierParams::from_ring_size`]
-/// and reuse across verifications.
+/// Contains only the PIOP parameters needed to construct prover and verifier
+/// instances from pre-built keys, without the KZG SRS required for key generation.
+///
+/// Cheap to construct from a ring size alone via [`RingContext::new`], or
+/// extractable from a [`RingSetup`] via [`RingSetup::ring_context`].
 #[derive(Clone)]
-pub struct RingVerifierParams<S: RingSuite> {
+pub struct RingContext<S: RingSuite> {
     /// PIOP parameters.
-    pub piop: PiopParams<S>,
+    pub piop_params: PiopParams<S>,
 }
 
-impl<S: RingSuite> RingVerifierParams<S> {
-    /// Construct verifier parameters for the given ring size.
-    pub fn from_ring_size(ring_size: usize) -> Self {
-        Self {
-            piop: piop_params::<S>(piop_domain_size::<S>(ring_size)),
-        }
+impl<S: RingSuite> RingContext<S> {
+    /// Construct context for the given ring size.
+    pub fn new(ring_size: usize) -> Self {
+        let domain_size = piop_domain_size::<S>(ring_size);
+        let piop_params = PiopParams::<S>::setup(
+            ring_proof::Domain::new(domain_size, true),
+            S::BLINDING_BASE.into_te(),
+            S::ACCUMULATOR_BASE.into_te(),
+            S::PADDING.into_te(),
+        );
+        Self { piop_params }
     }
 
-    /// The max ring size these parameters are able to handle.
+    /// The max ring size this context is able to handle.
     #[inline(always)]
     pub fn max_ring_size(&self) -> usize {
-        self.piop.keyset_part_size
+        self.piop_params.keyset_part_size
+    }
+
+    /// Create a prover instance for a specific position in the ring.
+    pub fn ring_prover(&self, prover_key: RingProverKey<S>, key_index: usize) -> RingProver<S> {
+        self.clone().into_ring_prover(prover_key, key_index)
     }
 
     /// Create a verifier instance from a verifier key.
-    pub fn verifier(&self, verifier_key: RingVerifierKey<S>) -> RingVerifier<S> {
+    pub fn ring_verifier(&self, verifier_key: RingVerifierKey<S>) -> RingVerifier<S> {
+        self.clone().into_ring_verifier(verifier_key)
+    }
+
+    /// Create a prover instance, consuming the context to avoid cloning.
+    pub fn into_ring_prover(self, prover_key: RingProverKey<S>, key_index: usize) -> RingProver<S> {
+        RingProver::<S>::init(
+            prover_key,
+            self.piop_params,
+            key_index,
+            ring_proof::ArkTranscript::new(const { &S::SUITE_ID.to_bytes() }),
+        )
+    }
+
+    /// Create a verifier instance, consuming the context to avoid cloning.
+    pub fn into_ring_verifier(self, verifier_key: RingVerifierKey<S>) -> RingVerifier<S> {
         RingVerifier::<S>::init(
             verifier_key,
-            self.piop.clone(),
+            self.piop_params,
             ring_proof::ArkTranscript::new(const { &S::SUITE_ID.to_bytes() }),
         )
     }
 }
 
-/// Ring proof parameters.
+/// Ring proof setup.
 ///
-/// Contains the cryptographic parameters needed for ring proof generation and verification:
-/// - `pcs`: Polynomial Commitment Scheme parameters (KZG setup)
-/// - `piop`: Polynomial Interactive Oracle Proof parameters
+/// Contains the cryptographic parameters needed for ring proof key construction,
+/// proving and verification:
+/// - `pcs_params`: Polynomial Commitment Scheme parameters (KZG setup)
+/// - `piop_params`: Polynomial Interactive Oracle Proof parameters
 #[derive(Clone)]
-pub struct RingProofParams<S: RingSuite> {
+pub struct RingSetup<S: RingSuite> {
     /// PCS parameters.
-    pub pcs: PcsParams<S>,
-    /// PIOP parameters.
-    pub piop: PiopParams<S>,
+    pub pcs_params: PcsParams<S>,
+    /// Ring context (PIOP parameters).
+    pub ring_ctx: RingContext<S>,
 }
 
-pub(crate) fn piop_params<S: RingSuite>(domain_size: usize) -> PiopParams<S> {
-    PiopParams::<S>::setup(
-        ring_proof::Domain::new(domain_size, true),
-        S::BLINDING_BASE.into_te(),
-        S::ACCUMULATOR_BASE.into_te(),
-        S::PADDING.into_te(),
-    )
+impl<S: RingSuite> core::ops::Deref for RingSetup<S> {
+    type Target = RingContext<S>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.ring_ctx
+    }
 }
 
-impl<S: RingSuite> RingProofParams<S> {
+impl<S: RingSuite> RingSetup<S> {
     /// Construct deterministic ring proof params for the given ring size.
     ///
     /// Creates parameters using a transcript-based RNG seeded with `seed`.
@@ -314,49 +342,33 @@ impl<S: RingSuite> RingProofParams<S> {
         // Keep only the required powers of tau
         pcs_params.powers_in_g1.truncate(pcs_domain_size);
         pcs_params.powers_in_g2.truncate(2);
-        let piop_domain_size = piop_domain_size::<S>(ring_size);
-        Ok(Self {
-            pcs: pcs_params,
-            piop: piop_params::<S>(piop_domain_size),
-        })
-    }
 
-    /// The max ring size these parameters are able to handle.
-    #[inline(always)]
-    pub fn max_ring_size(&self) -> usize {
-        self.piop.keyset_part_size
+        Ok(Self {
+            pcs_params,
+            ring_ctx: RingContext::new(ring_size),
+        })
     }
 
     /// Create a prover key for the given ring of public keys.
     ///
-    /// Returns `Error::InvalidData` if `pks` exceeds [`Self::max_ring_size`].
+    /// Returns `Error::InvalidData` if `pks` exceeds the max ring size.
     pub fn prover_key(&self, pks: &[AffinePoint<S>]) -> Result<RingProverKey<S>, Error> {
-        if pks.len() > self.max_ring_size() {
+        if pks.len() > self.piop_params.keyset_part_size {
             return Err(Error::InvalidData);
         }
         let pks = TEMapping::to_te_slice(pks);
-        Ok(ring_proof::index(&self.pcs, &self.piop, &pks).0)
-    }
-
-    /// Create a prover instance for a specific position in the ring.
-    pub fn prover(&self, prover_key: RingProverKey<S>, key_index: usize) -> RingProver<S> {
-        RingProver::<S>::init(
-            prover_key,
-            self.piop.clone(),
-            key_index,
-            ring_proof::ArkTranscript::new(const { &S::SUITE_ID.to_bytes() }),
-        )
+        Ok(ring_proof::index(&self.pcs_params, &self.piop_params, &pks).0)
     }
 
     /// Create a verifier key for the given ring of public keys.
     ///
-    /// Returns `Error::InvalidData` if `pks` exceeds [`Self::max_ring_size`].
+    /// Returns `Error::InvalidData` if `pks` exceeds the max ring size.
     pub fn verifier_key(&self, pks: &[AffinePoint<S>]) -> Result<RingVerifierKey<S>, Error> {
-        if pks.len() > self.max_ring_size() {
+        if pks.len() > self.piop_params.keyset_part_size {
             return Err(Error::InvalidData);
         }
         let pks = TEMapping::to_te_slice(pks);
-        Ok(ring_proof::index(&self.pcs, &self.piop, &pks).1)
+        Ok(ring_proof::index(&self.pcs_params, &self.piop_params, &pks).1)
     }
 
     /// Create a verifier key from a precomputed ring commitment.
@@ -368,33 +380,23 @@ impl<S: RingSuite> RingProofParams<S> {
         commitment: RingCommitment<S>,
     ) -> RingVerifierKey<S> {
         use ring_proof::pcs::PcsParams;
-        RingVerifierKey::<S>::from_commitment_and_kzg_vk(commitment, self.pcs.raw_vk())
+        RingVerifierKey::<S>::from_commitment_and_kzg_vk(commitment, self.pcs_params.raw_vk())
     }
 
     /// Create a builder for incremental construction of the verifier key.
     pub fn verifier_key_builder(&self) -> (VerifierKeyBuilder<S>, RingBuilderPcsParams<S>) {
         type RingBuilderKey<S> =
             ring_proof::ring::RingBuilderKey<BaseField<S>, <S as RingSuite>::Pairing>;
-        let piop_domain_size = piop_domain_size::<S>(self.piop.keyset_part_size);
-        let builder_key = RingBuilderKey::<S>::from_srs(&self.pcs, piop_domain_size);
+        let piop_domain_size = piop_domain_size::<S>(self.piop_params.keyset_part_size);
+        let builder_key = RingBuilderKey::<S>::from_srs(&self.pcs_params, piop_domain_size);
         let builder_pcs_params = RingBuilderPcsParams(builder_key.lis_in_g1);
         let builder = VerifierKeyBuilder::new(self, &builder_pcs_params);
         (builder, builder_pcs_params)
     }
 
-    /// Extract lightweight verifier parameters.
-    ///
-    /// Returns a [`RingVerifierParams`] that can be stored and reused without
-    /// carrying the KZG SRS.
-    pub fn verifier_params(&self) -> RingVerifierParams<S> {
-        RingVerifierParams {
-            piop: self.piop.clone(),
-        }
-    }
-
-    /// Create a verifier instance from a verifier key.
-    pub fn verifier(&self, verifier_key: RingVerifierKey<S>) -> RingVerifier<S> {
-        self.verifier_params().verifier(verifier_key)
+    /// Get a reference to the lightweight [`RingContext`].
+    pub fn ring_context(&self) -> &RingContext<S> {
+        &self.ring_ctx
     }
 
     /// Get the padding point.
@@ -407,21 +409,21 @@ impl<S: RingSuite> RingProofParams<S> {
     }
 }
 
-impl<S: RingSuite> CanonicalSerialize for RingProofParams<S> {
+impl<S: RingSuite> CanonicalSerialize for RingSetup<S> {
     fn serialize_with_mode<W: ark_serialize::Write>(
         &self,
         mut writer: W,
         compress: ark_serialize::Compress,
     ) -> Result<(), ark_serialize::SerializationError> {
-        self.pcs.serialize_with_mode(&mut writer, compress)
+        self.pcs_params.serialize_with_mode(&mut writer, compress)
     }
 
     fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
-        self.pcs.serialized_size(compress)
+        self.pcs_params.serialized_size(compress)
     }
 }
 
-impl<S: RingSuite> CanonicalDeserialize for RingProofParams<S> {
+impl<S: RingSuite> CanonicalDeserialize for RingSetup<S> {
     fn deserialize_with_mode<R: ark_serialize::Read>(
         mut reader: R,
         compress: ark_serialize::Compress,
@@ -432,17 +434,17 @@ impl<S: RingSuite> CanonicalDeserialize for RingProofParams<S> {
             compress,
             validate,
         )?;
-        let piop_domain_size = piop_domain_size_from_pcs_domain_size(pcs_params.powers_in_g1.len());
+        let ring_size = max_ring_size_from_pcs_domain_size::<S>(pcs_params.powers_in_g1.len());
         Ok(Self {
-            pcs: pcs_params,
-            piop: piop_params::<S>(piop_domain_size),
+            pcs_params,
+            ring_ctx: RingContext::new(ring_size),
         })
     }
 }
 
-impl<S: RingSuite> ark_serialize::Valid for RingProofParams<S> {
+impl<S: RingSuite> ark_serialize::Valid for RingSetup<S> {
     fn check(&self) -> Result<(), ark_serialize::SerializationError> {
-        self.pcs.check()
+        self.pcs_params.check()
     }
 }
 
@@ -502,12 +504,15 @@ impl<S: RingSuite> SrsLookup<S> for &RingBuilderPcsParams<S> {
 
 impl<S: RingSuite> VerifierKeyBuilder<S> {
     /// Create a new empty ring verifier key builder.
-    pub fn new(params: &RingProofParams<S>, lookup: impl SrsLookup<S>) -> Self {
+    pub fn new(ring_setup: &RingSetup<S>, lookup: impl SrsLookup<S>) -> Self {
         use ring_proof::pcs::PcsParams;
         let lookup = |range: Range<usize>| lookup.lookup(range).ok_or(());
-        let raw_vk = params.pcs.raw_vk();
-        let partial =
-            PartialRingCommitment::<S>::empty(&params.piop, lookup, raw_vk.g1.into_group());
+        let raw_vk = ring_setup.pcs_params.raw_vk();
+        let partial = PartialRingCommitment::<S>::empty(
+            &ring_setup.piop_params,
+            lookup,
+            raw_vk.g1.into_group(),
+        );
         VerifierKeyBuilder { partial, raw_vk }
     }
 
@@ -632,9 +637,9 @@ macro_rules! ring_suite_types {
         #[allow(dead_code)]
         pub type PiopParams = $crate::ring::PiopParams<$suite>;
         #[allow(dead_code)]
-        pub type RingVerifierParams = $crate::ring::RingVerifierParams<$suite>;
+        pub type RingContext = $crate::ring::RingContext<$suite>;
         #[allow(dead_code)]
-        pub type RingProofParams = $crate::ring::RingProofParams<$suite>;
+        pub type RingSetup = $crate::ring::RingSetup<$suite>;
         #[allow(dead_code)]
         pub type RingProverKey = $crate::ring::RingProverKey<$suite>;
         #[allow(dead_code)]
@@ -833,7 +838,7 @@ pub(crate) mod testing {
     #[allow(unused)]
     pub fn prove_verify<S: RingSuite>() {
         let rng = &mut ark_std::test_rng();
-        let params = RingProofParams::<S>::from_rand(TEST_RING_SIZE, rng);
+        let ring_setup = RingSetup::<S>::from_rand(TEST_RING_SIZE, rng);
 
         let secret = Secret::<S>::from_seed(TEST_SEED);
         let public = secret.public();
@@ -842,13 +847,14 @@ pub(crate) mod testing {
         let prover_idx = 3;
         pks[prover_idx] = public.0;
 
-        let prover_key = params.prover_key(&pks).unwrap();
-        let prover = params.prover(prover_key, prover_idx);
+        let ring_ctx = ring_setup.ring_context();
+        let prover_key = ring_setup.prover_key(&pks).unwrap();
+        let prover = ring_ctx.ring_prover(prover_key, prover_idx);
 
         let item = BatchItem::<S>::new(&secret, &prover, rng);
 
-        let verifier_key = params.verifier_key(&pks).unwrap();
-        let verifier = params.verifier(verifier_key);
+        let verifier_key = ring_setup.verifier_key(&pks).unwrap();
+        let verifier = ring_ctx.ring_verifier(verifier_key);
         let result = Public::verify(item.io, &item.ad, &item.proof, &verifier);
         assert!(result.is_ok());
     }
@@ -859,7 +865,7 @@ pub(crate) mod testing {
         use ring::{Prover, Verifier};
 
         let rng = &mut ark_std::test_rng();
-        let params = RingProofParams::<S>::from_rand(TEST_RING_SIZE, rng);
+        let ring_setup = RingSetup::<S>::from_rand(TEST_RING_SIZE, rng);
 
         let secret = Secret::<S>::from_seed(TEST_SEED);
         let public = secret.public();
@@ -868,11 +874,12 @@ pub(crate) mod testing {
         let prover_idx = 3;
         pks[prover_idx] = public.0;
 
-        let prover_key = params.prover_key(&pks).unwrap();
-        let prover = params.prover(prover_key, prover_idx);
+        let ring_ctx = ring_setup.ring_context();
+        let prover_key = ring_setup.prover_key(&pks).unwrap();
+        let prover = ring_ctx.ring_prover(prover_key, prover_idx);
 
-        let verifier_key = params.verifier_key(&pks).unwrap();
-        let verifier = params.verifier(verifier_key);
+        let verifier_key = ring_setup.verifier_key(&pks).unwrap();
+        let verifier = ring_ctx.ring_verifier(verifier_key);
 
         let mut ios: Vec<VrfIo<S>> = (0..3u8)
             .map(|i| {
@@ -904,7 +911,7 @@ pub(crate) mod testing {
         const BATCH_SIZE: usize = 3 * TEST_RING_SIZE;
 
         let rng = &mut ark_std::test_rng();
-        let params = RingProofParams::<S>::from_rand(TEST_RING_SIZE, rng);
+        let ring_setup = RingSetup::<S>::from_rand(TEST_RING_SIZE, rng);
 
         let secret = Secret::<S>::from_seed(TEST_SEED);
         let public = secret.public();
@@ -913,8 +920,9 @@ pub(crate) mod testing {
         let prover_idx = 3;
         pks[prover_idx] = public.0;
 
-        let prover_key = params.prover_key(&pks).unwrap();
-        let prover = params.prover(prover_key, prover_idx);
+        let ring_ctx = ring_setup.ring_context();
+        let prover_key = ring_setup.prover_key(&pks).unwrap();
+        let prover = ring_ctx.ring_prover(prover_key, prover_idx);
 
         // Generate proofs in parallel
         let batch: Vec<_> = (0..BATCH_SIZE)
@@ -924,8 +932,8 @@ pub(crate) mod testing {
             })
             .collect();
 
-        let verifier_key = params.verifier_key(&pks).unwrap();
-        let verifier = params.verifier(verifier_key);
+        let verifier_key = ring_setup.verifier_key(&pks).unwrap();
+        let verifier = ring_ctx.ring_verifier(verifier_key);
 
         // Batch verify all proofs
         let mut batch_verifier = BatchVerifier::<S>::new(verifier);
@@ -943,8 +951,8 @@ pub(crate) mod testing {
 
         println!("============================================================");
 
-        let verifier_key = params.verifier_key(&pks).unwrap();
-        let verifier = params.verifier(verifier_key);
+        let verifier_key = ring_setup.verifier_key(&pks).unwrap();
+        let verifier = ring_ctx.ring_verifier(verifier_key);
         let mut batch_verifier = BatchVerifier::<S>::new(verifier);
         let start = std::time::Instant::now();
         common::timed("Proofs push", || {
@@ -957,8 +965,8 @@ pub(crate) mod testing {
 
         println!("============================================================");
 
-        let verifier_key = params.verifier_key(&pks).unwrap();
-        let verifier = params.verifier(verifier_key);
+        let verifier_key = ring_setup.verifier_key(&pks).unwrap();
+        let verifier = ring_ctx.ring_verifier(verifier_key);
         let mut batch_verifier = BatchVerifier::<S>::new(verifier);
         let start = std::time::Instant::now();
         let prepared = common::timed("Proofs prepare", || {
@@ -1010,24 +1018,25 @@ pub(crate) mod testing {
         use crate::testing::{random_val, random_vec};
 
         let rng = &mut ark_std::test_rng();
-        let params = RingProofParams::<S>::from_rand(TEST_RING_SIZE, rng);
+        let ring_setup = RingSetup::<S>::from_rand(TEST_RING_SIZE, rng);
 
         let secret = Secret::<S>::from_seed(TEST_SEED);
         let public = secret.public();
         let input = Input::from_affine_unchecked(common::random_val(Some(rng)));
         let io = secret.vrf_io(input);
 
-        let ring_size = params.max_ring_size();
+        let ring_ctx = ring_setup.ring_context();
+        let ring_size = ring_ctx.max_ring_size();
         let prover_idx = random_val::<usize>(Some(rng)) % ring_size;
         let mut pks = random_vec::<AffinePoint<S>>(ring_size, Some(rng));
         pks[prover_idx] = public.0;
 
-        let prover_key = params.prover_key(&pks).unwrap();
-        let prover = params.prover(prover_key, prover_idx);
+        let prover_key = ring_setup.prover_key(&pks).unwrap();
+        let prover = ring_ctx.ring_prover(prover_key, prover_idx);
         let proof = secret.prove(io, b"foo", &prover);
 
         // Incremental ring verifier key construction
-        let (mut vk_builder, lookup) = params.verifier_key_builder();
+        let (mut vk_builder, lookup) = ring_setup.verifier_key_builder();
         assert_eq!(vk_builder.free_slots(), pks.len());
 
         let extra_pk = random_val::<AffinePoint<S>>(Some(rng));
@@ -1046,7 +1055,7 @@ pub(crate) mod testing {
         let extra_pk = random_val::<AffinePoint<S>>(Some(rng));
         assert_eq!(vk_builder.append(&[extra_pk], &lookup).unwrap_err(), 0);
         let verifier_key = vk_builder.finalize();
-        let verifier = params.verifier(verifier_key);
+        let verifier = ring_ctx.ring_verifier(verifier_key);
         let result = Public::verify(io, b"foo", &proof, &verifier);
         assert!(result.is_ok());
     }
@@ -1163,10 +1172,10 @@ pub(crate) mod testing {
     pub trait RingSuiteExt: RingSuite + crate::testing::SuiteExt {
         const SRS_FILE: &str;
 
-        fn params() -> &'static RingProofParams<Self>;
+        fn ring_setup() -> &'static RingSetup<Self>;
 
         #[allow(unused)]
-        fn load_context() -> RingProofParams<Self> {
+        fn load_context() -> RingSetup<Self> {
             use ark_serialize::CanonicalDeserialize;
             use std::{fs::File, io::Read};
             let mut file = File::open(Self::SRS_FILE).unwrap();
@@ -1174,17 +1183,19 @@ pub(crate) mod testing {
             file.read_to_end(&mut buf).unwrap();
             let pcs_params =
                 PcsParams::<Self>::deserialize_uncompressed_unchecked(&mut &buf[..]).unwrap();
-            RingProofParams::from_pcs_params(crate::ring::testing::TEST_RING_SIZE, pcs_params)
-                .unwrap()
+            RingSetup::from_pcs_params(crate::ring::testing::TEST_RING_SIZE, pcs_params).unwrap()
         }
 
         #[allow(unused)]
-        fn write_context(params: &RingProofParams<Self>) {
+        fn write_context(ring_setup: &RingSetup<Self>) {
             use ark_serialize::CanonicalSerialize;
             use std::{fs::File, io::Write};
             let mut file = File::create(Self::SRS_FILE).unwrap();
             let mut buf = Vec::new();
-            params.pcs.serialize_uncompressed(&mut buf).unwrap();
+            ring_setup
+                .pcs_params
+                .serialize_uncompressed(&mut buf)
+                .unwrap();
             file.write_all(&buf).unwrap();
         }
     }
@@ -1225,7 +1236,7 @@ pub(crate) mod testing {
                 output: Output::from_affine_unchecked(pedersen.base.gamma),
             };
 
-            let params = <S as RingSuiteExt>::params();
+            let ring_setup = <S as RingSuiteExt>::ring_setup();
 
             use ark_std::rand::SeedableRng;
             let rng = &mut ark_std::rand::rngs::StdRng::from_seed([42; 32]);
@@ -1233,11 +1244,12 @@ pub(crate) mod testing {
             let mut ring_pks = common::random_vec::<AffinePoint<S>>(TEST_RING_SIZE, Some(rng));
             ring_pks[prover_idx] = public.0;
 
-            let prover_key = params.prover_key(&ring_pks).unwrap();
-            let prover = params.prover(prover_key, prover_idx);
+            let ring_ctx = ring_setup.ring_context();
+            let prover_key = ring_setup.prover_key(&ring_pks).unwrap();
+            let prover = ring_ctx.ring_prover(prover_key, prover_idx);
             let proof = secret.prove(io, ad, &prover);
 
-            let verifier_key = params.verifier_key(&ring_pks).unwrap();
+            let verifier_key = ring_setup.verifier_key(&ring_pks).unwrap();
             let ring_pks_com = verifier_key.commitment();
 
             {
@@ -1290,15 +1302,16 @@ pub(crate) mod testing {
             let public = secret.public();
             assert_eq!(public.0, self.pedersen.base.pk);
 
-            let params = <S as RingSuiteExt>::params();
+            let ring_setup = <S as RingSuiteExt>::ring_setup();
 
             let prover_idx = self.ring_pks.iter().position(|&pk| pk == public.0).unwrap();
 
-            let prover_key = params.prover_key(&self.ring_pks).unwrap();
-            let prover = params.prover(prover_key, prover_idx);
+            let ring_ctx = ring_setup.ring_context();
+            let prover_key = ring_setup.prover_key(&self.ring_pks).unwrap();
+            let prover = ring_ctx.ring_prover(prover_key, prover_idx);
 
-            let verifier_key = params.verifier_key(&self.ring_pks).unwrap();
-            let verifier = params.verifier(verifier_key);
+            let verifier_key = ring_setup.verifier_key(&self.ring_pks).unwrap();
+            let verifier = ring_ctx.ring_verifier(verifier_key);
 
             let proof = secret.prove(io, &self.pedersen.base.ad, &prover);
 

--- a/src/suites/baby_jubjub.rs
+++ b/src/suites/baby_jubjub.rs
@@ -120,7 +120,7 @@ pub(crate) mod tests {
         fn ring_setup() -> &'static RingSetup {
             use std::sync::OnceLock;
             static RING_SETUP: OnceLock<RingSetup> = OnceLock::new();
-            RING_SETUP.get_or_init(Self::load_context)
+            RING_SETUP.get_or_init(Self::load_ring_setup)
         }
     }
 }

--- a/src/suites/baby_jubjub.rs
+++ b/src/suites/baby_jubjub.rs
@@ -117,10 +117,10 @@ pub(crate) mod tests {
     impl crate::ring::testing::RingSuiteExt for ThisSuite {
         const SRS_FILE: &str = crate::testing::BN254_PCS_SRS_FILE;
 
-        fn params() -> &'static RingProofParams {
+        fn ring_setup() -> &'static RingSetup {
             use std::sync::OnceLock;
-            static PARAMS: OnceLock<RingProofParams> = OnceLock::new();
-            PARAMS.get_or_init(Self::load_context)
+            static RING_SETUP: OnceLock<RingSetup> = OnceLock::new();
+            RING_SETUP.get_or_init(Self::load_context)
         }
     }
 }

--- a/src/suites/bandersnatch.rs
+++ b/src/suites/bandersnatch.rs
@@ -129,10 +129,10 @@ pub(crate) mod tests {
     impl crate::ring::testing::RingSuiteExt for ThisSuite {
         const SRS_FILE: &str = crate::testing::BLS12_381_PCS_SRS_FILE;
 
-        fn params() -> &'static RingProofParams {
+        fn ring_setup() -> &'static RingSetup {
             use std::sync::OnceLock;
-            static PARAMS: OnceLock<RingProofParams> = OnceLock::new();
-            PARAMS.get_or_init(Self::load_context)
+            static RING_SETUP: OnceLock<RingSetup> = OnceLock::new();
+            RING_SETUP.get_or_init(Self::load_context)
         }
     }
 

--- a/src/suites/bandersnatch.rs
+++ b/src/suites/bandersnatch.rs
@@ -132,7 +132,7 @@ pub(crate) mod tests {
         fn ring_setup() -> &'static RingSetup {
             use std::sync::OnceLock;
             static RING_SETUP: OnceLock<RingSetup> = OnceLock::new();
-            RING_SETUP.get_or_init(Self::load_context)
+            RING_SETUP.get_or_init(Self::load_ring_setup)
         }
     }
 

--- a/src/suites/bandersnatch_shake128.rs
+++ b/src/suites/bandersnatch_shake128.rs
@@ -98,7 +98,7 @@ pub(crate) mod tests {
         fn ring_setup() -> &'static RingSetup {
             use std::sync::OnceLock;
             static RING_SETUP: OnceLock<RingSetup> = OnceLock::new();
-            RING_SETUP.get_or_init(Self::load_context)
+            RING_SETUP.get_or_init(Self::load_ring_setup)
         }
     }
 

--- a/src/suites/bandersnatch_shake128.rs
+++ b/src/suites/bandersnatch_shake128.rs
@@ -95,10 +95,10 @@ pub(crate) mod tests {
     impl crate::ring::testing::RingSuiteExt for ThisSuite {
         const SRS_FILE: &str = crate::testing::BLS12_381_PCS_SRS_FILE;
 
-        fn params() -> &'static RingProofParams {
+        fn ring_setup() -> &'static RingSetup {
             use std::sync::OnceLock;
-            static PARAMS: OnceLock<RingProofParams> = OnceLock::new();
-            PARAMS.get_or_init(Self::load_context)
+            static RING_SETUP: OnceLock<RingSetup> = OnceLock::new();
+            RING_SETUP.get_or_init(Self::load_context)
         }
     }
 

--- a/src/suites/bandersnatch_sw.rs
+++ b/src/suites/bandersnatch_sw.rs
@@ -139,7 +139,7 @@ mod tests {
         fn ring_setup() -> &'static RingSetup {
             use std::sync::OnceLock;
             static RING_SETUP: OnceLock<RingSetup> = OnceLock::new();
-            RING_SETUP.get_or_init(Self::load_context)
+            RING_SETUP.get_or_init(Self::load_ring_setup)
         }
     }
 

--- a/src/suites/bandersnatch_sw.rs
+++ b/src/suites/bandersnatch_sw.rs
@@ -136,10 +136,10 @@ mod tests {
     impl crate::ring::testing::RingSuiteExt for ThisSuite {
         const SRS_FILE: &str = crate::testing::BLS12_381_PCS_SRS_FILE;
 
-        fn params() -> &'static RingProofParams {
+        fn ring_setup() -> &'static RingSetup {
             use std::sync::OnceLock;
-            static PARAMS: OnceLock<RingProofParams> = OnceLock::new();
-            PARAMS.get_or_init(Self::load_context)
+            static RING_SETUP: OnceLock<RingSetup> = OnceLock::new();
+            RING_SETUP.get_or_init(Self::load_context)
         }
     }
 

--- a/src/suites/jubjub.rs
+++ b/src/suites/jubjub.rs
@@ -121,7 +121,7 @@ pub(crate) mod tests {
         fn ring_setup() -> &'static RingSetup {
             use std::sync::OnceLock;
             static RING_SETUP: OnceLock<RingSetup> = OnceLock::new();
-            RING_SETUP.get_or_init(Self::load_context)
+            RING_SETUP.get_or_init(Self::load_ring_setup)
         }
     }
 }

--- a/src/suites/jubjub.rs
+++ b/src/suites/jubjub.rs
@@ -118,10 +118,10 @@ pub(crate) mod tests {
     impl crate::ring::testing::RingSuiteExt for ThisSuite {
         const SRS_FILE: &str = crate::testing::BLS12_381_PCS_SRS_FILE;
 
-        fn params() -> &'static RingProofParams {
+        fn ring_setup() -> &'static RingSetup {
             use std::sync::OnceLock;
-            static PARAMS: OnceLock<RingProofParams> = OnceLock::new();
-            PARAMS.get_or_init(Self::load_context)
+            static RING_SETUP: OnceLock<RingSetup> = OnceLock::new();
+            RING_SETUP.get_or_init(Self::load_context)
         }
     }
 }


### PR DESCRIPTION
Refactor ring proof parameter types to cleanly separate key generation (setup phase) from prover/verifier instantiation (runtime phase).

- Introduce `RingContext`, a lightweight struct holding only the PIOP parameters. Can be constructed cheaply from a ring size via `RingContext::new(ring_size)` without requiring the KZG SRS. Provides `ring_prover()`/`ring_verifier()` construction methods.
- Rename `RingProofParams` to `RingSetup`. It now holds a RingContext internally and implements Deref<Target = RingContext>. Key generation methods (prover_key, verifier_key, verifier_key_builder) remain on RingSetup; prover/verifier construction moves to RingContext.
- Remove RingProofParams::verifier_no_context, superseded by RingContext::new.

