### PR TITLE
Reject identity VRF I/O points and key commitment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Public::from_affine`, checked deserialization, and the thin and tiny
   verifiers (including batch verification) return `Error::InvalidData` for
   identity keys.
+- The group identity is now rejected as a VRF input or output point. The pair
+  `(0, 0)` satisfies `O = x * I` for every secret key, so it binds its VRF
+  output to no signer. `Input::from_affine`, `Output::from_affine`, checked
+  deserialization of both, and all four verifiers (including batch
+  verification) return `Error::InvalidData` for such a pair.
+- The group identity is now rejected as a Pedersen key commitment. Its opening
+  is the public `(0, 0)`, so anyone can build a proof that satisfies the
+  commitment equation without a secret.
+
+  The identity remains accepted for the nonce commitments `R` and `Ok`, which
+  commit to nothing and are not part of the extraction argument. `Ok` is
+  necessarily the identity when no I/O pair is supplied. This matches the
+  Bandersnatch VRF specification, section 3.2, 3.3, 4.2 and 4.4 step 1.
 
 ## [0.5.1] - 2026-06-12
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,8 +413,33 @@ impl<S: Suite> Public<S> {
 /// VRF input point generic over the cipher suite.
 ///
 /// Elliptic curve point representing the VRF input.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, CanonicalSerialize)]
 pub struct Input<S: Suite>(pub AffinePoint<S>);
+
+impl<S: Suite> ark_serialize::Valid for Input<S> {
+    fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+        if self.is_identity() {
+            return Err(ark_serialize::SerializationError::InvalidData);
+        }
+        self.0.check()
+    }
+}
+
+impl<S: Suite> CanonicalDeserialize for Input<S> {
+    fn deserialize_with_mode<R: ark_serialize::Read>(
+        reader: R,
+        compress: ark_serialize::Compress,
+        validate: ark_serialize::Validate,
+    ) -> Result<Self, ark_serialize::SerializationError> {
+        let point =
+            AffinePoint::<S>::deserialize_with_mode(reader, compress, ark_serialize::Validate::No)?;
+        let input = Self(point);
+        if matches!(validate, ark_serialize::Validate::Yes) {
+            ark_serialize::Valid::check(&input)?;
+        }
+        Ok(input)
+    }
+}
 
 impl<S: Suite> Input<S> {
     /// Construct from [`Suite::data_to_point`].
@@ -426,53 +451,104 @@ impl<S: Suite> Input<S> {
 }
 
 impl<S: Suite> Input<S> {
-    /// Construct from an affine point with subgroup validation.
+    /// Construct from an affine point with validation.
     ///
-    /// Returns `Error::InvalidData` if the point is not in the prime-order subgroup.
+    /// Returns `Error::InvalidData` if the point is not in the prime-order
+    /// subgroup or is the group identity.
     ///
     /// Note: this only validates subgroup membership, not that the point was
     /// produced by hash-to-curve. The caller is still responsible for ensuring
     /// the point is not in a known discrete-log relation with the suite
     /// generator (required for Thin-VRF soundness).
     pub fn from_affine(value: AffinePoint<S>) -> Result<Self, Error> {
-        ark_serialize::Valid::check(&value).map_err(|_| Error::InvalidData)?;
-        Ok(Self(value))
+        let input = Self(value);
+        ark_serialize::Valid::check(&input).map_err(|_| Error::InvalidData)?;
+        Ok(input)
     }
 
-    /// Construct from an affine point without subgroup checks.
+    /// Construct from an affine point without validation.
     ///
     /// # Safety
     ///
-    /// The caller must ensure that `value` is in the prime-order subgroup and
-    /// was produced by a hash-to-curve procedure (or is otherwise not in a
-    /// known discrete-log relation with the suite generator). The latter is
-    /// required for the soundness of schemes like Thin-VRF where the input
-    /// and generator are delinearized into a single check.
+    /// The caller must ensure that `value` is in the prime-order subgroup, is
+    /// not the group identity, and was produced by a hash-to-curve procedure
+    /// (or is otherwise not in a known discrete-log relation with the suite
+    /// generator). The latter is required for the soundness of schemes like
+    /// Thin-VRF where the input and generator are delinearized into a single
+    /// check.
     pub fn from_affine_unchecked(value: AffinePoint<S>) -> Self {
         Self(value)
+    }
+
+    /// Whether the point is the group identity.
+    ///
+    /// The identity is not a usable VRF input: its output is the identity for
+    /// every secret key, so the pair proves nothing about the signer. Verifiers
+    /// reject it explicitly rather than relying on the caller having gone
+    /// through a checked constructor.
+    pub(crate) fn is_identity(&self) -> bool {
+        self.0.is_zero()
     }
 }
 
 /// VRF output point generic over the cipher suite.
 ///
 /// Elliptic curve point representing the VRF output.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, CanonicalSerialize)]
 pub struct Output<S: Suite>(pub AffinePoint<S>);
 
+impl<S: Suite> ark_serialize::Valid for Output<S> {
+    fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+        if self.is_identity() {
+            return Err(ark_serialize::SerializationError::InvalidData);
+        }
+        self.0.check()
+    }
+}
+
+impl<S: Suite> CanonicalDeserialize for Output<S> {
+    fn deserialize_with_mode<R: ark_serialize::Read>(
+        reader: R,
+        compress: ark_serialize::Compress,
+        validate: ark_serialize::Validate,
+    ) -> Result<Self, ark_serialize::SerializationError> {
+        let point =
+            AffinePoint::<S>::deserialize_with_mode(reader, compress, ark_serialize::Validate::No)?;
+        let output = Self(point);
+        if matches!(validate, ark_serialize::Validate::Yes) {
+            ark_serialize::Valid::check(&output)?;
+        }
+        Ok(output)
+    }
+}
+
 impl<S: Suite> Output<S> {
-    /// Construct from an affine point with subgroup validation.
+    /// Construct from an affine point with validation.
     ///
-    /// Returns `Error::InvalidData` if the point is not in the prime-order subgroup.
+    /// Returns `Error::InvalidData` if the point is not in the prime-order
+    /// subgroup or is the group identity.
     pub fn from_affine(value: AffinePoint<S>) -> Result<Self, Error> {
-        ark_serialize::Valid::check(&value).map_err(|_| Error::InvalidData)?;
-        Ok(Self(value))
+        let output = Self(value);
+        ark_serialize::Valid::check(&output).map_err(|_| Error::InvalidData)?;
+        Ok(output)
     }
 
-    /// Construct from an affine point without subgroup checks.
+    /// Construct from an affine point without validation.
     ///
-    /// The caller must ensure `value` is in the prime-order subgroup.
+    /// The caller must ensure `value` is in the prime-order subgroup and is not
+    /// the group identity.
     pub fn from_affine_unchecked(value: AffinePoint<S>) -> Self {
         Self(value)
+    }
+
+    /// Whether the point is the group identity.
+    ///
+    /// The identity is the VRF output of every secret key over the identity
+    /// input, so a pair holding it proves nothing about the signer. Verifiers
+    /// reject it explicitly rather than relying on the caller having gone
+    /// through a checked constructor.
+    pub(crate) fn is_identity(&self) -> bool {
+        self.0.is_zero()
     }
 }
 
@@ -493,6 +569,16 @@ pub struct VrfIo<S: Suite> {
 impl<S: Suite> AsRef<[VrfIo<S>]> for VrfIo<S> {
     fn as_ref(&self) -> &[VrfIo<S>] {
         core::slice::from_ref(self)
+    }
+}
+
+impl<S: Suite> VrfIo<S> {
+    /// Whether either point of the pair is the group identity.
+    ///
+    /// Such a pair is satisfied by every secret key, so it binds its VRF output
+    /// to no signer. Verifiers reject it before evaluating their equations.
+    pub(crate) fn has_identity(&self) -> bool {
+        self.input.is_identity() || self.output.is_identity()
     }
 }
 
@@ -571,6 +657,31 @@ mod tests {
         // Unchecked paths are documented as skipping validation.
         assert!(crate::Public::<S>::deserialize_compressed_unchecked(&buf[..]).is_ok());
         assert!(crate::Public::<S>::from_affine_unchecked(identity).is_identity());
+    }
+
+    /// The pair `(I, O) = (0, 0)` satisfies `O = x * I` for every secret key,
+    /// so it binds a VRF output to no key at all. Like the identity public key
+    /// it passes the subgroup check, so the checked constructors must reject it
+    /// on their own.
+    #[test]
+    fn identity_io_point_construction_rejected() {
+        type S = TestSuite;
+
+        let identity = AffinePoint::<S>::zero();
+
+        assert!(crate::Input::<S>::from_affine(identity).is_err());
+        assert!(crate::Output::<S>::from_affine(identity).is_err());
+
+        let mut buf = Vec::new();
+        identity.serialize_compressed(&mut buf).unwrap();
+        assert!(crate::Input::<S>::deserialize_compressed(&buf[..]).is_err());
+        assert!(crate::Output::<S>::deserialize_compressed(&buf[..]).is_err());
+
+        // Unchecked paths are documented as skipping validation.
+        assert!(crate::Input::<S>::deserialize_compressed_unchecked(&buf[..]).is_ok());
+        assert!(crate::Output::<S>::deserialize_compressed_unchecked(&buf[..]).is_ok());
+        assert!(crate::Input::<S>::from_affine_unchecked(identity).is_identity());
+        assert!(crate::Output::<S>::from_affine_unchecked(identity).is_identity());
     }
 
     #[test]

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -111,12 +111,21 @@ pub trait Prover<S: PedersenSuite> {
 /// Using unchecked constructors (e.g. [`Input::from_affine_unchecked`]) places
 /// the burden of subgroup validation on the caller. Passing points with
 /// cofactor components leads to undefined verification behavior.
+///
+/// The group identity is checked unconditionally, for the key commitment and
+/// for every I/O pair. Neither binds the proof to a signer: the opening of the
+/// identity commitment is the public `(0, 0)`, and a pair holding the identity
+/// is satisfied by every secret key. It stays a legal value for the nonce
+/// commitments `R` and `Ok`, which commit to nothing, and `Ok` is necessarily
+/// the identity when no I/O pair is supplied.
 pub trait Verifier<S: PedersenSuite> {
     /// Verify a proof for the given VRF I/O pairs and additional data.
     ///
     /// Multiple I/O pairs are delinearized into a single merged pair before verifying.
     ///
-    /// Returns `Ok(())` if verification succeeds, `Err(Error::VerificationFailure)` otherwise.
+    /// Returns `Ok(())` if verification succeeds, `Err(Error::InvalidData)` if the
+    /// key commitment or any I/O pair point is the group identity,
+    /// `Err(Error::VerificationFailure)` otherwise.
     fn verify(
         ios: impl AsRef<[VrfIo<S>]>,
         ad: impl AsRef<[u8]>,
@@ -190,6 +199,19 @@ impl<S: PedersenSuite> Verifier<S> for Public<S> {
             sb,
         } = proof;
 
+        // Yb = 0 is the commitment of the opening (0, 0), which is public, so
+        // anyone can satisfy Eq2 without knowing a secret.
+        if pk_com.is_zero() {
+            return Err(Error::InvalidData);
+        }
+
+        // A pair holding the identity satisfies O = x*I for every x, so it
+        // binds its VRF output to no signer.
+        let ios = ios.as_ref();
+        if ios.iter().any(VrfIo::has_identity) {
+            return Err(Error::InvalidData);
+        }
+
         let (mut t, io) = utils::vrf_transcript::<S>(DomSep::PedersenVrf, ios, ad);
 
         // Absorb Yb into the transcript
@@ -239,6 +261,10 @@ pub struct BatchItem<S: PedersenSuite> {
     ok: AffinePoint<S>,
     s: ScalarField<S>,
     sb: ScalarField<S>,
+    /// Set when a supplied I/O pair held the identity. Recorded here because
+    /// only the merged pair survives, and that one is legitimately the identity
+    /// when no pair is supplied at all.
+    io_identity: bool,
 }
 
 impl<S: PedersenSuite> BatchItem<S> {
@@ -248,6 +274,8 @@ impl<S: PedersenSuite> BatchItem<S> {
     /// verification. This is cheap (one hash, no scalar multiplications)
     /// and can be done in parallel.
     pub fn new(ios: impl AsRef<[VrfIo<S>]>, ad: impl AsRef<[u8]>, proof: &Proof<S>) -> Self {
+        let ios = ios.as_ref();
+        let io_identity = ios.iter().any(VrfIo::has_identity);
         let (mut t, io) = utils::vrf_transcript::<S>(DomSep::PedersenVrf, ios, ad);
         t.absorb_serialize(&proof.pk_com);
         let c = S::challenge(&[&proof.r, &proof.ok], Some(t));
@@ -260,6 +288,7 @@ impl<S: PedersenSuite> BatchItem<S> {
             ok: proof.ok,
             s: proof.s,
             sb: proof.sb,
+            io_identity,
         }
     }
 }
@@ -306,11 +335,21 @@ impl<S: PedersenSuite> BatchVerifier<S> {
     ///
     /// The random linear combination yields a (5N + 2)-point MSM.
     ///
-    /// Returns `Ok(())` if all proofs verify, `Err(VerificationFailure)` otherwise.
+    /// Returns `Ok(())` if all proofs verify, `Err(Error::InvalidData)` if any
+    /// key commitment or I/O pair point is the group identity,
+    /// `Err(VerificationFailure)` otherwise.
     pub fn verify(&self) -> Result<(), Error> {
         let items = &self.items;
         if items.is_empty() {
             return Ok(());
+        }
+
+        // Checked here rather than in `BatchItem::new`, which cannot fail.
+        if items
+            .iter()
+            .any(|item| item.pk_com.is_zero() || item.io_identity)
+        {
+            return Err(Error::InvalidData);
         }
 
         let n = items.len();
@@ -522,6 +561,79 @@ pub(crate) mod testing {
         assert!(Public::verify(ios, b"baz", &proof).is_err());
     }
 
+    /// An I/O pair holding the identity must be rejected by both verifiers.
+    ///
+    /// `(I, O) = (0, 0)` satisfies `O = x * I` for every secret key, so both
+    /// verification equations accept it and two different keys produce two
+    /// valid proofs for the same pair. The pair therefore binds its VRF output
+    /// to nobody, and only an explicit check keeps it out. The second case
+    /// hides the bad pair behind a good one, where the merged pair alone is not
+    /// enough to catch it.
+    pub fn identity_io_pair_rejected<S: PedersenSuite>() {
+        use pedersen::{BatchVerifier, Prover, Verifier};
+
+        let identity_io = VrfIo::<S> {
+            input: Input(AffinePoint::<S>::zero()),
+            output: Output(AffinePoint::<S>::zero()),
+        };
+
+        for seed in [TEST_SEED, [0x11; 32]] {
+            let secret = Secret::<S>::from_seed(seed);
+
+            let (proof, _) = secret.prove([identity_io], b"forgery");
+            assert!(Public::verify([identity_io], b"forgery", &proof).is_err());
+
+            let mut batch = BatchVerifier::new();
+            batch.push([identity_io], b"forgery", &proof);
+            assert!(batch.verify().is_err());
+
+            let good_io = secret.vrf_io(Input::new(b"good").unwrap());
+            let ios = [good_io, identity_io];
+            let (proof, _) = secret.prove(ios, b"forgery");
+            assert!(Public::verify(ios, b"forgery", &proof).is_err());
+
+            let mut batch = BatchVerifier::new();
+            batch.push(ios, b"forgery", &proof);
+            assert!(batch.verify().is_err());
+        }
+    }
+
+    /// An identity key commitment must be rejected by both verifiers.
+    ///
+    /// `Yb = 0` is the commitment of the opening `(x, b) = (0, 0)`, which is
+    /// public. The proof below is built without any secret: both responses are
+    /// the nonces themselves, since the challenge multiplies zero. Both
+    /// verification equations hold, so only an explicit check keeps it out.
+    pub fn identity_key_commitment_rejected<S: PedersenSuite>() {
+        use pedersen::{BatchVerifier, Verifier};
+
+        let ios: [VrfIo<S>; 0] = [];
+        let ad = b"forgery";
+
+        let (mut t, io) = utils::vrf_transcript::<S>(DomSep::PedersenVrf, ios, ad);
+        let pk_com = AffinePoint::<S>::zero();
+        t.absorb_serialize(&pk_com);
+
+        let k = ScalarField::<S>::from(7u64);
+        let kb = ScalarField::<S>::from(11u64);
+        let r = (S::generator() * k + S::BLINDING_BASE * kb).into_affine();
+        let ok = (io.input.0 * k).into_affine();
+
+        let proof = Proof {
+            pk_com,
+            r,
+            ok,
+            s: k,
+            sb: kb,
+        };
+
+        assert!(Public::verify(ios, ad, &proof).is_err());
+
+        let mut batch = BatchVerifier::new();
+        batch.push(ios, ad, &proof);
+        assert!(batch.verify().is_err());
+    }
+
     pub fn blinding_base_check<S: PedersenSuite>()
     where
         AffinePoint<S>: CheckPoint,
@@ -564,6 +676,16 @@ pub(crate) mod testing {
                 #[test]
                 fn batch_verify() {
                     $crate::pedersen::testing::batch_verify::<$suite>();
+                }
+
+                #[test]
+                fn identity_io_pair_rejected() {
+                    $crate::pedersen::testing::identity_io_pair_rejected::<$suite>();
+                }
+
+                #[test]
+                fn identity_key_commitment_rejected() {
+                    $crate::pedersen::testing::identity_key_commitment_rejected::<$suite>();
                 }
 
                 #[test]

--- a/src/thin.rs
+++ b/src/thin.rs
@@ -87,15 +87,19 @@ pub trait Prover<S: ThinVrfSuite> {
 /// the burden of subgroup validation on the caller. Passing points with
 /// cofactor components leads to undefined verification behavior.
 ///
-/// An identity public key is the one case checked unconditionally, as its
-/// secret scalar is publicly known.
+/// The group identity is checked unconditionally, for the public key and for
+/// every I/O pair. Neither binds the proof to a signer: the secret scalar of
+/// the identity key is publicly known, and a pair holding the identity is
+/// satisfied by every secret key. It stays a legal value for the nonce
+/// commitment `R`, which commits to nothing.
 pub trait Verifier<S: ThinVrfSuite> {
     /// Verify a proof for the given VRF I/O pairs and additional data.
     ///
     /// Multiple I/O pairs are delinearized into a single merged pair before verifying.
     ///
     /// Returns `Ok(())` if verification succeeds, `Err(Error::InvalidData)` if the
-    /// public key is the group identity, `Err(Error::VerificationFailure)` otherwise.
+    /// public key or any I/O pair point is the group identity,
+    /// `Err(Error::VerificationFailure)` otherwise.
     fn verify(
         &self,
         ios: impl AsRef<[VrfIo<S>]>,
@@ -134,6 +138,13 @@ impl<S: ThinVrfSuite> Verifier<S> for Public<S> {
         // With Y = 0 the challenge term drops out of the equation below and
         // anyone can pick s and set R = s * G.
         if self.is_identity() {
+            return Err(Error::InvalidData);
+        }
+
+        // A pair holding the identity satisfies O = x*I for every x, so it
+        // binds its VRF output to no signer.
+        let ios = ios.as_ref();
+        if ios.iter().any(VrfIo::has_identity) {
             return Err(Error::InvalidData);
         }
 
@@ -241,7 +252,8 @@ impl<S: ThinVrfSuite> BatchVerifier<S> {
     /// pairs in proof j).
     ///
     /// Returns `Ok(())` if all proofs verify, `Err(Error::InvalidData)` if any
-    /// public key is the group identity, `Err(VerificationFailure)` otherwise.
+    /// public key or I/O pair point is the group identity,
+    /// `Err(VerificationFailure)` otherwise.
     pub fn verify(&self) -> Result<(), Error> {
         use ark_ec::VariableBaseMSM;
         use ark_ff::Zero;
@@ -251,7 +263,10 @@ impl<S: ThinVrfSuite> BatchVerifier<S> {
             return Ok(());
         }
         // Checked here rather than in `prepare`, which cannot fail.
-        if items.iter().any(|item| item.pk.is_identity()) {
+        if items
+            .iter()
+            .any(|item| item.pk.is_identity() || item.ios.iter().any(VrfIo::has_identity))
+        {
             return Err(Error::InvalidData);
         }
 
@@ -417,6 +432,44 @@ pub(crate) mod testing {
         assert!(batch.verify().is_err());
     }
 
+    /// An I/O pair holding the identity must be rejected by both verifiers.
+    ///
+    /// `(I, O) = (0, 0)` satisfies `O = x * I` for every secret key, so the
+    /// verification equation accepts it and two different keys produce two
+    /// valid proofs for the same pair. The pair therefore binds its VRF output
+    /// to nobody, and only an explicit check keeps it out. The second case
+    /// hides the bad pair behind a good one, where the merged pair alone is not
+    /// enough to catch it.
+    pub fn identity_io_pair_rejected<S: ThinVrfSuite>() {
+        use thin::{BatchVerifier, Prover, Verifier};
+
+        let identity_io = VrfIo::<S> {
+            input: Input(AffinePoint::<S>::zero()),
+            output: Output(AffinePoint::<S>::zero()),
+        };
+
+        for seed in [common::TEST_SEED, [0x11; 32]] {
+            let secret = Secret::<S>::from_seed(seed);
+            let public = secret.public();
+
+            let proof = secret.prove([identity_io], b"forgery");
+            assert!(public.verify([identity_io], b"forgery", &proof).is_err());
+
+            let mut batch = BatchVerifier::new();
+            batch.push(&public, [identity_io], b"forgery", &proof);
+            assert!(batch.verify().is_err());
+
+            let good_io = secret.vrf_io(Input::new(b"good").unwrap());
+            let ios = [good_io, identity_io];
+            let proof = secret.prove(ios, b"forgery");
+            assert!(public.verify(ios, b"forgery", &proof).is_err());
+
+            let mut batch = BatchVerifier::new();
+            batch.push(&public, ios, b"forgery", &proof);
+            assert!(batch.verify().is_err());
+        }
+    }
+
     /// N=3 VRF pairs: verify succeeds; tampered output/input/ad fails.
     pub fn prove_verify_multi<S: ThinVrfSuite>() {
         use thin::{Prover, Verifier};
@@ -496,6 +549,11 @@ pub(crate) mod testing {
                 #[test]
                 fn identity_public_key_rejected() {
                     $crate::thin::testing::identity_public_key_rejected::<$suite>();
+                }
+
+                #[test]
+                fn identity_io_pair_rejected() {
+                    $crate::thin::testing::identity_io_pair_rejected::<$suite>();
                 }
 
                 $crate::test_vectors!($crate::thin::testing::TestVector<$suite>);

--- a/src/tiny.rs
+++ b/src/tiny.rs
@@ -130,15 +130,18 @@ pub trait Prover<S: TinySuite> {
 /// the burden of subgroup validation on the caller. Passing points with
 /// cofactor components leads to undefined verification behavior.
 ///
-/// An identity public key is the one case checked unconditionally, as its
-/// secret scalar is publicly known.
+/// The group identity is checked unconditionally, for the public key and for
+/// every I/O pair. Neither binds the proof to a signer: the secret scalar of
+/// the identity key is publicly known, and a pair holding the identity is
+/// satisfied by every secret key.
 pub trait Verifier<S: TinySuite> {
     /// Verify a proof for the given VRF I/O pairs and additional data.
     ///
     /// Multiple I/O pairs are delinearized into a single merged pair before verifying.
     ///
     /// Returns `Ok(())` if verification succeeds, `Err(Error::InvalidData)` if the
-    /// public key is the group identity, `Err(Error::VerificationFailure)` otherwise.
+    /// public key or any I/O pair point is the group identity,
+    /// `Err(Error::VerificationFailure)` otherwise.
     fn verify(
         &self,
         ios: impl AsRef<[VrfIo<S>]>,
@@ -186,6 +189,13 @@ impl<S: TinySuite> Verifier<S> for Public<S> {
         // With Y = 0 the challenge term drops out of the equation below and
         // anyone can produce a matching (c, s) pair.
         if self.is_identity() {
+            return Err(Error::InvalidData);
+        }
+
+        // A pair holding the identity satisfies O = x*I for every x, so it
+        // binds its VRF output to no signer.
+        let ios = ios.as_ref();
+        if ios.iter().any(VrfIo::has_identity) {
             return Err(Error::InvalidData);
         }
 
@@ -269,6 +279,34 @@ pub mod testing {
         assert!(identity.verify([], b"forgery", &proof).is_err());
     }
 
+    /// An I/O pair holding the identity must be rejected by the verifier.
+    ///
+    /// `(I, O) = (0, 0)` satisfies `O = x * I` for every secret key, so the
+    /// verification equation accepts it and two different keys produce two
+    /// valid proofs for the same pair. The pair therefore binds its VRF output
+    /// to nobody, and only an explicit check keeps it out. The second case
+    /// hides the bad pair behind a good one, where the merged pair alone is not
+    /// enough to catch it.
+    pub fn identity_io_pair_rejected<S: TinySuite>() {
+        let identity_io = VrfIo::<S> {
+            input: Input(AffinePoint::<S>::zero()),
+            output: Output(AffinePoint::<S>::zero()),
+        };
+
+        for seed in [common::TEST_SEED, [0x11; 32]] {
+            let secret = Secret::<S>::from_seed(seed);
+            let public = secret.public();
+
+            let proof = secret.prove([identity_io], b"forgery");
+            assert!(public.verify([identity_io], b"forgery", &proof).is_err());
+
+            let good_io = secret.vrf_io(Input::new(b"good").unwrap());
+            let ios = [good_io, identity_io];
+            let proof = secret.prove(ios, b"forgery");
+            assert!(public.verify(ios, b"forgery", &proof).is_err());
+        }
+    }
+
     /// N=3 multi proof: verify succeeds; tampered output/input/ad fails.
     pub fn prove_verify_multi<S: TinySuite>() {
         let secret = Secret::<S>::from_seed(common::TEST_SEED);
@@ -331,6 +369,11 @@ pub mod testing {
                 #[test]
                 fn identity_public_key_rejected() {
                     $crate::tiny::testing::identity_public_key_rejected::<$suite>();
+                }
+
+                #[test]
+                fn identity_io_pair_rejected() {
+                    $crate::tiny::testing::identity_io_pair_rejected::<$suite>();
                 }
 
                 $crate::test_vectors!($crate::tiny::testing::TestVector<$suite>);


### PR DESCRIPTION
The pair (0, 0) satisfies O = x*I for every secret key, and the identity key commitment opens to the public (0, 0). Neither binds a proof to a signer. Checked at the Input/Output type boundary and in all four verifiers, single and batch.